### PR TITLE
Add development mode for mariadb chart

### DIFF
--- a/mariadb/templates/bin/_seed.sh.tpl
+++ b/mariadb/templates/bin/_seed.sh.tpl
@@ -57,7 +57,11 @@ function wait_for_cluster {
 # the implementation will be switched to Deployment
 # (using anti-affinity feature).
 
+{{- if .Values.development.enabled }}
+REPLICAS=1
+{{- else }}
 REPLICAS={{ .Values.replicas }}
+{{- end }}
 
 if [ "$REPLICAS" -eq 1 ] ; then
     echo "Requested to build one-instance MariaDB cluster. There is no need to run seed. Exiting."

--- a/mariadb/templates/bin/_start.sh.tpl
+++ b/mariadb/templates/bin/_start.sh.tpl
@@ -5,7 +5,11 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 sudo chown mysql: /var/lib/mysql
 rm -rf /var/lib/mysql/lost+found
 
+{{- if .Values.development.enabled }}
+REPLICAS=1
+{{- else }}
 REPLICAS={{ .Values.replicas }}
+{{- end }}
 PETSET_NAME={{ printf "%s" .Values.service_name }}
 INIT_MARKER="/var/lib/mysql/init_done"
 

--- a/mariadb/templates/deployment.yaml
+++ b/mariadb/templates/deployment.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ .Values.service_name }}
 spec:
   serviceName: "{{ .Values.service_name }}"
-  replicas: 3
+{{- if .Values.development.enabled }}
+  replicas: 1
+{{- else }}
+  replicas: {{ .Values.replicas }}
+{{- end }}
   template:
     metadata:
       labels:
@@ -149,7 +153,12 @@ spec:
             name: mariadb-etc
         - name: wsrep
           configMap:
-            name: mariadb-etc  
+            name: mariadb-etc
+{{- if .Values.development.enabled }}
+        - name: mysql-data
+          hostPath:
+            path: {{ .Values.developer.storage_path }}
+{{- else }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data
@@ -160,3 +169,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.volume.size }}
+{{- end }}

--- a/mariadb/templates/deployment.yaml
+++ b/mariadb/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
 {{- if .Values.development.enabled }}
         - name: mysql-data
           hostPath:
-            path: {{ .Values.developer.storage_path }}
+            path: {{ .Values.development.storage_path }}
 {{- else }}
   volumeClaimTemplates:
   - metadata:

--- a/mariadb/templates/service.yaml
+++ b/mariadb/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
     # one. If it creates a new cluster when it should have joined an existing
     # one, we'd end up with two separate clusters listening at the same service
     # endpoint, which would be very bad.
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "false"
 spec:
   ports:
     - name: db

--- a/mariadb/values.yaml
+++ b/mariadb/values.yaml
@@ -7,6 +7,20 @@
 # below when changing this value
 replicas: 3
 
+# this flag allows a "leaner" version of this chart to be installed
+# likely lacking any resiliency or persistence, but will help
+# both laptop developers and cicd systems
+#
+# it will deploy a single instance of mariadb, use nodeDir
+# for persistence and satisfy the mariadb-seed job with
+# a busybox mock
+#
+# note enabling this flag takes precedence when enabled and
+# will override certain things, like the replicas requested
+development:
+  enabled: false
+  storage_path: /var/lib/openstack-helm/mariadb
+
 # this drives the service name, and statefulset name
 service_name: mariadb
 


### PR DESCRIPTION
This can be enabled with:

helm install --name mariadb --set development.enabled=true local/mariadb

This will ensure only a single replica is used and that PVCs (which
require a persistent volume solution) like ceph are not used.  Instead
this flag enables a single replica with hostDir storage using the
host path defined in values.yaml which defaults to the following:

/var/lib/openstack-helm/mariadb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/71)
<!-- Reviewable:end -->
