### PR TITLE
Fix helm deployment names

### DIFF
--- a/docs/developer/minikube.md
+++ b/docs/developer/minikube.md
@@ -160,8 +160,8 @@ $ helm install --name=rabbitmq local/rabbitmq --namespace=openstack
 $ helm install --name=keystone local/keystone --namespace=openstack
 $ helm install --name=horizon local/horizon --namespace=openstack
 $ helm install --name=glance local/glance --namespace=openstack
-$ helm install --name=glance local/nova --namespace=openstack
-$ helm install --name=glance local/neutron --namespace=openstack
+$ helm install --name=nova local/nova --namespace=openstack
+$ helm install --name=neutron local/neutron --namespace=openstack
 ```
 
 # Horizon Management


### PR DESCRIPTION
The deployment names for nova and neutron were both listed as
'glance'. Changed the names to match the services

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/73)
<!-- Reviewable:end -->
