### PR TITLE
Update Memcached Chart to increase image portability

### DIFF
--- a/memcached/templates/deployment.yaml
+++ b/memcached/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: memcached
 spec:
-  replicas: 1
+  replicas: {{ .Values.resources.memcached.replicas }}
   template:
     metadata:
       labels:
@@ -14,20 +14,15 @@ spec:
       containers:
         - name: memcached
           image: {{ .Values.images.memcached }}
-          imagePullPolicy: Always
-          env:
-            - name: INTERFACE_NAME
-              value: "eth0"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "memcached -v -p {{ .Values.network.port }} -U 0 -c 8192 -m 1024"
+          imagePullPolicy: {{ .Values.images.pull_policy }}
+          command: ["sh", "-xec"]
+          args:
+            - |
+              exec memcached -v \
+                -p {{ .Values.network.port }} \
+                -U 0 \
+                -c {{ .Values.memcached.max_connections }} \
+                -m {{ .Values.memcached.memory }};
           ports:
             - containerPort: {{ .Values.network.port }}
           readinessProbe:

--- a/memcached/values.yaml
+++ b/memcached/values.yaml
@@ -5,6 +5,7 @@
 
 images:
   memcached: quay.io/stackanetes/stackanetes-memcached:newton
+  pull_policy: "IfNotPresent"
 
 labels:
   node_selector_key: openstack-control-plane
@@ -12,3 +13,11 @@ labels:
 
 network:
   port: 11211
+
+memcached:
+  memory: 1024
+  max_connections: 8192
+
+resources:
+  memcached:
+    replicas: 1


### PR DESCRIPTION
This commit updates the Memcached chart to allow use with images other than Stackanetes, define ImagePullPolicy, and provide config params in the values.yaml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/75)
<!-- Reviewable:end -->
