### PR TITLE
Endpoint lookup fixes for consistent keystone catalog endpoints

### DIFF
--- a/common/templates/_endpoints.tpl
+++ b/common/templates/_endpoints.tpl
@@ -1,9 +1,94 @@
 #-----------------------------------------
 # endpoints
 #-----------------------------------------
+
+# this should be a generic function leveraging a tuple
+# for input, e.g. { endpoint keystone internal . }
+# however, constructing this appears to be a
+# herculean effort in gotpl
+
 {{- define "endpoint_keystone_internal" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
 {{- with .Values.endpoints.keystone -}}
-	{{.scheme}}://{{.hosts.internal | default .hosts.default}}:{{.port.public}}{{.path}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.public}}{{.path}}
 {{- end -}}
 {{- end -}}
+
+{{- define "endpoint_keystone_admin" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- with .Values.endpoints.keystone -}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.admin}}{{.path}}
+{{- end -}}
+{{- end -}}
+
+{{- define "endpoint_nova_api_internal" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- with .Values.endpoints.nova -}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.api}}{{.path}}
+{{- end -}}
+{{- end -}}
+
+{{- define "endpoint_nova_metadata_internal" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- with .Values.endpoints.nova -}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.metadata}}{{.path}}
+{{- end -}}
+{{- end -}}
+
+{{- define "endpoint_nova_novncproxy_internal" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- with .Values.endpoints.nova -}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.novncproxy}}{{.path}}
+{{- end -}}
+{{- end -}}
+
+{{- define "endpoint_glance_api_internal" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- with .Values.endpoints.glance -}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.api}}{{.path}}
+{{- end -}}
+{{- end -}}
+
+{{- define "endpoint_glance_registry_internal" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- with .Values.endpoints.glance -}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.registry}}{{.path}}
+{{- end -}}
+{{- end -}}
+
+{{- define "endpoint_neutron_api_internal" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- with .Values.endpoints.neutron -}}
+	{{.scheme}}://{{.hosts.internal | default .hosts.default}}.{{ $fqdn }}:{{.port.api}}{{.path}}
+{{- end -}}
+{{- end -}}
+
+#-------------------------------
+# kolla helpers
+#-------------------------------
+{{ define "keystone_auth" }}{'auth_url':'{{ include "endpoint_keystone_internal" . }}', 'username':'{{ .Values.keystone.admin_user }}','password':'{{ .Values.keystone.admin_password }}','project_name':'{{ .Values.keystone.admin_project_name }}','domain_name':'default'}{{end}}
 

--- a/common/templates/_hosts.tpl
+++ b/common/templates/_hosts.tpl
@@ -2,6 +2,14 @@
 {{- define "region"}}cluster{{- end}}
 {{- define "tld"}}local{{- end}}
 
+{{- define "fqdn" -}}
+{{- $fqdn := .Release.Namespace -}}
+{{- if .Values.endpoints.fqdn -}}
+{{- $fqdn := .Values.endpoints.fqdn -}}
+{{- end -}}
+{{- $fqdn -}}
+{{- end -}}
+
 #-----------------------------------------
 # hosts
 #-----------------------------------------
@@ -17,3 +25,14 @@
 {{- define "keystone_api_endpoint_host_internal"}}keystone-api.{{.Release.Namespace}}.svc.{{ include "region" . }}.{{ include "tld" . }}{{- end}}
 {{- define "keystone_api_endpoint_host_public"}}keystone-api.{{ include "region" . }}.{{ include "tld" . }}{{- end}}
 {{- define "keystone_api_endpoint_host_admin_ext"}}keystone-api.{{ include "region" . }}.{{ include "tld" . }}{{- end}}
+
+# glance defaults
+{{- define "glance_registry_host"}}glance-registry.{{ include "fqdn" . }}{{- end}}
+
+# nova defaults
+{{- define "nova_metadata_host"}}nova-api.{{ include "fqdn" . }}{{- end}}
+
+# neutron defaults
+{{- define "neutron_db_host"}}{{ include "mariadb_host" . }}{{- end}}
+{{- define "neutron_rabbit_host"}}{{- include "rabbitmq_host" .}}{{- end}}
+

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -7,3 +7,6 @@ global:
   region: cluster
   tld: local
 
+endpoints:
+  fqdn: null
+

--- a/glance/templates/_helpers.tpl
+++ b/glance/templates/_helpers.tpl
@@ -1,5 +1,0 @@
-{{- define "joinListWithColon" -}}
-{{ range $k, $v := . }}{{ if $k }},{{ end }}{{ $v }}{{ end }}
-{{- end -}}
-
-{{ define "keystone_auth" }}{'auth_url':'{{ .Values.keystone.auth_url }}', 'username':'{{ .Values.keystone.admin_user }}','password':'{{ .Values.keystone.admin_password }}','project_name':'{{ .Values.keystone.admin_project_name }}','domain_name':'default'}{{end}}

--- a/glance/templates/ceph.client.glance.keyring.yaml
+++ b/glance/templates/ceph.client.glance.keyring.yaml
@@ -5,5 +5,9 @@ metadata:
 data:
   ceph.client.{{ .Values.ceph.glance_user }}.keyring: |+
     [client.{{ .Values.ceph.glance_user }}]
+    {{- if .Values.ceph.glance_keyring }}
         key = {{ .Values.ceph.glance_keyring }}
-    
+    {{- else }}
+        key = {{- include "secrets/ceph-client-key" . -}}
+    {{- end }}
+

--- a/glance/templates/ceph.conf.yaml
+++ b/glance/templates/ceph.conf.yaml
@@ -7,12 +7,17 @@ data:
     [global]
     rgw_thread_pool_size = 1024
     rgw_num_rados_handles = 100
+    {{- if .Values.ceph.monitors }}
     [mon]
     {{ range .Values.ceph.monitors }}
         [mon.{{ . }}]
           host = {{ . }}
           mon_addr = {{ . }}
     {{ end }}
+    {{- else }}
+    mon_host = ceph-mon.ceph
+    {{- end }}
     [client]
       rbd_cache_enabled = true
       rbd_cache_writethrough_until_flush = true
+

--- a/glance/templates/glance-api.conf.yaml
+++ b/glance/templates/glance-api.conf.yaml
@@ -12,7 +12,7 @@ data:
     bind_port = {{ .Values.network.port.api }}
 
     workers = {{ .Values.misc.workers }}
-    registry_host = glance-registry
+    registry_host = {{ include "glance_registry_host" . }}
 
     # Enable Copy-on-Write
     show_image_direct_url = True
@@ -45,3 +45,4 @@ data:
     rbd_store_user = {{ .Values.ceph.glance_user }}
     rbd_store_ceph_conf = /etc/ceph/ceph.conf
     rbd_store_chunk_size = 8
+

--- a/glance/templates/post.sh.yaml
+++ b/glance/templates/post.sh.yaml
@@ -6,12 +6,13 @@ data:
   post.sh: |+
     #!/bin/bash
     set -ex
+    export HOME=/tmp
     
     ansible localhost -vvv -m kolla_keystone_service -a "service_name=glance \
     service_type=image \
     description='Openstack Image' \
     endpoint_region='{{ .Values.keystone.glance_region_name }}' \
-    url='http://glance-api:{{ .Values.network.port.api }}' \
+    url='{{ include "endpoint_glance_api_internal" . }}' \
     interface=admin \
     region_name='{{ .Values.keystone.admin_region_name }}' \
     auth='{{ include "keystone_auth" . }}'" \
@@ -21,7 +22,7 @@ data:
     service_type=image \
     description='Openstack Image' \
     endpoint_region='{{ .Values.keystone.glance_region_name }}' \
-    url='http://glance-api:{{ .Values.network.port.api }}' \
+    url='{{ include "endpoint_glance_api_internal" . }}' \
     interface=internal \
     region_name='{{ .Values.keystone.admin_region_name }}' \
     auth='{{ include "keystone_auth" . }}'" \
@@ -31,7 +32,7 @@ data:
     service_type=image \
     description='Openstack Image' \
     endpoint_region='{{ .Values.keystone.glance_region_name }}' \
-    url='http://glance-api:{{ .Values.network.port.api }}' \
+    url='{{ include "endpoint_glance_api_internal" . }}' \
     interface=public \
     region_name='{{ .Values.keystone.admin_region_name }}' \
     auth='{{ include "keystone_auth" . }}'" \
@@ -44,3 +45,4 @@ data:
     region_name={{ .Values.keystone.admin_region_name }} \
     auth='{{ include "keystone_auth" . }}'" \
     -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"
+

--- a/glance/templates/post.yaml
+++ b/glance/templates/post.yaml
@@ -32,6 +32,8 @@ spec:
           }
         ]'
     spec:
+      nodeSelector:
+        {{ .Values.labels.node_selector_key }}: {{ .Values.labels.node_selector_value }}
       restartPolicy: OnFailure
       containers:
         - name: glance-post
@@ -51,3 +53,4 @@ spec:
         - name: postsh
           configMap:
             name: glance-postsh
+

--- a/glance/values.yaml
+++ b/glance/values.yaml
@@ -33,7 +33,7 @@ network:
   port:
     api: 9292
     registry: 9191
-  ip_address: "{{ .IP }}"
+  ip_address: "0.0.0.0"
 
 database:
   address: mariadb
@@ -47,9 +47,12 @@ database:
 ceph:
   enabled: true
   monitors: []
-  glance_user: "glance"
+  glance_user: "admin"
   glance_pool: "images"
-  glance_keyring: ""
+  # a null value for the keyring will
+  # attempt to use the key from
+  # common/secrets/ceph-client-key
+  glance_keyring: null
 
 misc:
   workers: 8
@@ -98,3 +101,27 @@ dependencies:
     - keystone-api
     - glance-api
     - glance-registry
+
+# typically overriden by environmental 
+# values, but should include all endpoints
+# required by this chart
+endpoints:
+  glance:
+    hosts:
+      default: glance-api
+    type: image
+    path: null
+    scheme: 'http'
+    port:
+      api: 9292
+      registry: 9191
+  keystone:
+    hosts:
+      default: keystone-api
+    path: /v3
+    type: identity
+    scheme: 'http'
+    port:
+        admin: 35357
+        public: 5000
+

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -38,6 +38,6 @@ endpoints:
     type: identity
     scheme: 'http'
     port:
-        admin: 35356
+        admin: 35357
         public: 5000
 

--- a/keystone/templates/_helpers.tpl
+++ b/keystone/templates/_helpers.tpl
@@ -1,3 +1,0 @@
-{{- define "joinListWithColon" -}}
-{{ range $k, $v := . }}{{ if $k }},{{ end }}{{ $v }}{{ end }}
-{{- end -}}

--- a/keystone/templates/bin/_db-sync.sh.tpl
+++ b/keystone/templates/bin/_db-sync.sh.tpl
@@ -15,7 +15,8 @@ set -ex
 keystone-manage db_sync
 kolla_keystone_bootstrap {{ .Values.keystone.admin_user }} {{ .Values.keystone.admin_password }} \
   {{ .Values.keystone.admin_project_name }} admin \
-  {{ .Values.keystone.scheme }}://{{ include "keystone_api_endpoint_host_admin" . }}:{{ .Values.network.port.admin }}/{{ .Values.keystone.version }} \
-  {{ .Values.keystone.scheme }}://{{ include "keystone_api_endpoint_host_internal" . }}:{{ .Values.network.port.public }}/{{ .Values.keystone.version }} \
-  {{ .Values.keystone.scheme }}://{{ include "keystone_api_endpoint_host_public" . }}:{{ .Values.network.port.public }}/{{ .Values.keystone.version }} \
+  {{ include "endpoint_keystone_admin" . }} \
+  {{ include "endpoint_keystone_internal" . }} \
+  {{ include "endpoint_keystone_internal" . }} \
   {{ .Values.keystone.admin_region_name }}
+

--- a/keystone/templates/etc/_keystone.conf.tpl
+++ b/keystone/templates/etc/_keystone.conf.tpl
@@ -9,11 +9,11 @@ connection = mysql+pymysql://{{ .Values.database.keystone_user }}:{{ .Values.dat
 max_retries = -1
 
 [memcache]
-servers = {{ include "memcached_host" . }}
+servers = {{ include "memcached_host" . }}:11211
 
 [cache]
 backend = dogpile.cache.memcached
-memcache_servers = {{ include "memcached_host" . }}
+memcache_servers = {{ include "memcached_host" . }}:11211
 config_prefix = cache.keystone
-distributed_lock = True
 enabled = True
+

--- a/keystone/values.yaml
+++ b/keystone/values.yaml
@@ -17,7 +17,7 @@ images:
   pull_policy: "IfNotPresent"
 
 keystone:
-  version: v2.0
+  version: v3
   scheme: http
   admin_region_name: RegionOne
   admin_user: admin
@@ -67,3 +67,18 @@ dependencies:
     - mariadb-seed
     service:
     - mariadb
+
+# typically overriden by environmental
+# values, but should include all endpoints
+# required by this chart
+endpoints:
+  keystone:
+    hosts:
+      default: keystone-api
+    path: /v3
+    type: identity
+    scheme: 'http'
+    port:
+        admin: 35357
+        public: 5000
+


### PR DESCRIPTION
This introduces changes across several charts, for consistent
endpoint lookup routines.  Today, only the internal endpoints
are defined (and copied to admin and public).  This can later
be expanded to handle unique public and admin endpoints.

This ensures the catalog is populated with consistent URLs
for all services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/82)
<!-- Reviewable:end -->
