### PR TITLE
Removed the ``workers`` configuration from keystone.conf

### DIFF
--- a/keystone/templates/etc/_keystone.conf.tpl
+++ b/keystone/templates/etc/_keystone.conf.tpl
@@ -2,7 +2,6 @@
 debug = {{ .Values.misc.debug }}
 use_syslog = False
 use_stderr = True
-workers = {{ .Values.misc.workers }}
 
 [database]
 connection = mysql+pymysql://{{ .Values.database.keystone_user }}:{{ .Values.database.keystone_password }}@{{ include "keystone_db_host" . }}/{{ .Values.database.keystone_database_name }}

--- a/keystone/values.yaml
+++ b/keystone/values.yaml
@@ -38,11 +38,11 @@ network:
   # alanmeadows(TODO): I seem unable to use {{ .IP }} here
   # but it does work for wsrep.conf in mariadb, I have spent
   # time trying to figure this out am completely stumped
-  # 
+  #
   # helm --debug --dry-run shows me that the config map
   # contains {{ .IP }} but its simply translated by K8s
   # to ""
-  ip_address: "0.0.0.0"    
+  ip_address: "0.0.0.0"
 
 database:
   port: 3306
@@ -53,12 +53,11 @@ database:
   keystone_user: keystone
 
 misc:
-  workers: 8
   debug: false
 
 dependencies:
   api:
-    jobs: 
+    jobs:
     - mariadb-seed
     - keystone-db-sync
     service:


### PR DESCRIPTION
The configuration of ``worker`` can be removed for two reasons:

  * In Mitaka, it is two separate parameters:
    ``public_workers`` and ``admin_workers`` under section
    [eventlet_server], as shown in [1].  In master (Ocata),
    these options were removed.
  * In the preferred keystone deployment of using u/wsgi, and not
    eventlet server, this setting does not really take effect - as
    Apache will manage this instead of keystone.

These options can be removed.  Also, removed extra EOL spaces.

[1] https://github.com/openstack/keystone/blob/stable/mitaka/etc/keystone.conf.sample#L678-L696

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/108)
<!-- Reviewable:end -->
