### PR TITLE
Use Upstream Memcached Image

### DIFF
--- a/memcached/values.yaml
+++ b/memcached/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 images:
-  memcached: quay.io/stackanetes/stackanetes-memcached:newton
+  memcached: docker.io/memcached:latest
   pull_policy: "IfNotPresent"
 
 upgrades:

--- a/memcached/values.yaml
+++ b/memcached/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 images:
-  memcached: docker.io/memcached:latest
+  memcached: docker.io/memcached:1.4
   pull_policy: "IfNotPresent"
 
 upgrades:


### PR DESCRIPTION
This commit changes the default Memcached Image to the upstream one from the Docker Hub:
 * https://hub.docker.com/_/memcached/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/109)
<!-- Reviewable:end -->
