### PR TITLE
Allow specifying the keystone token provider

### DIFF
--- a/keystone/templates/etc/_keystone.conf.tpl
+++ b/keystone/templates/etc/_keystone.conf.tpl
@@ -1,5 +1,5 @@
 [DEFAULT]
-debug = {{ .Values.misc.debug }}
+debug = {{ .Values.api.default.debug }}
 use_syslog = False
 use_stderr = True
 
@@ -9,6 +9,9 @@ max_retries = -1
 
 [memcache]
 servers = {{ include "memcached_host" . }}:11211
+
+[token]
+provider = {{ .Values.api.token.provider }}
 
 [cache]
 backend = dogpile.cache.memcached

--- a/keystone/values.yaml
+++ b/keystone/values.yaml
@@ -31,6 +31,12 @@ keystone:
   admin_password: password
   admin_project_name: admin
 
+api:
+  default:
+    debug: false
+  token:
+    provider: uuid
+
 network:
   port:
     admin: 35357
@@ -51,9 +57,6 @@ database:
   keystone_database_name: keystone
   keystone_password: password
   keystone_user: keystone
-
-misc:
-  debug: false
 
 dependencies:
   api:


### PR DESCRIPTION
The new default for ocata+ is fernet tokens which not all
container images support.  This allows the operator to
specify the token provider, allowing uuid token usage in
images which is required until the infrastructure to setup
and distribute fernet keys is created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/112)
<!-- Reviewable:end -->
