### PR TITLE
Update Heat to mount policy at engine pods and set client endpoints

### DIFF
--- a/heat/templates/etc/_heat.conf.tpl
+++ b/heat/templates/etc/_heat.conf.tpl
@@ -80,3 +80,11 @@ region_name = {{ .Values.keystone.heat_trustee_region_name }}
 user_domain_name = {{ .Values.keystone.heat_trustee_user_domain }}
 username = {{ .Values.keystone.heat_trustee_user }}
 password = {{ .Values.keystone.heat_trustee_password }}
+
+
+[clients]
+endpoint_type = internalURL
+
+[clients_keystone]
+endpoint_type = internalURL
+auth_uri = {{ include "endpoint_keystone_internal" . }}

--- a/heat/templates/statefulset-engine.yaml
+++ b/heat/templates/statefulset-engine.yaml
@@ -55,11 +55,18 @@ spec:
               mountPath: /etc/heat/conf/heat.conf
               subPath: heat.conf
               readOnly: true
+            - name: heatpolicy
+              mountPath: /etc/heat/policy.json
+              subPath: policy.json
+              readOnly: true
       volumes:
         - name: pod-etc-heat
           emptyDir: {}
         - name: pod-var-cache-heat
           emptyDir: {}
         - name: heatconf
+          configMap:
+            name: heat-etc
+        - name: heatpolicy
           configMap:
             name: heat-etc

--- a/heat/values.yaml
+++ b/heat/values.yaml
@@ -108,7 +108,7 @@ resources:
     workers: 8
 
 misc:
-  debug: false
+  debug: true
 
 secrets:
   keystone_admin:


### PR DESCRIPTION
The initial heat commit produced a working API, but did not configure the clients correctly. This commit rectifies that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/113)
<!-- Reviewable:end -->
