### PR TITLE
Bugfixes for functional release tagging

### DIFF
--- a/glance/templates/configmap-etc.yaml
+++ b/glance/templates/configmap-etc.yaml
@@ -5,8 +5,8 @@ metadata:
 data:
   ceph.conf: |+
 {{ tuple "etc/_ceph.conf.tpl" . | include "template" | indent 4 }}
-  ceph.client.glance.keyring.yaml: |+
-{{ tuple "etc/_ceph.client.glance.keyring.yaml.tpl" . | include "template" | indent 4 }}
+  ceph.client.{{ .Values.ceph.glance_user }}.keyring: |+
+{{ tuple "etc/_ceph.client.glance.keyring.tpl" . | include "template" | indent 4 }}
   glance-api.conf: |+
 {{ tuple "etc/_glance-api.conf.tpl" . | include "template" | indent 4 }}
   glance-api-paste.ini: |+

--- a/glance/templates/deployment-api.yaml
+++ b/glance/templates/deployment-api.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         app: glance-api
       annotations:
+        configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
 {{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
         ]'

--- a/glance/templates/deployment-registry.yaml
+++ b/glance/templates/deployment-registry.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: glance-registry
       annotations:
+        configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
 {{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
         ]'

--- a/glance/templates/etc/_ceph.client.glance.keyring.tpl
+++ b/glance/templates/etc/_ceph.client.glance.keyring.tpl
@@ -1,0 +1,6 @@
+[client.{{ .Values.ceph.glance_user }}]
+{{- if .Values.ceph.glance_keyring }}
+    key = {{ .Values.ceph.glance_keyring }}
+{{- else }}
+    key = {{- include "secrets/ceph-client-key" . -}}
+{{- end }}

--- a/glance/templates/etc/_ceph.client.glance.keyring.yaml.tpl
+++ b/glance/templates/etc/_ceph.client.glance.keyring.yaml.tpl
@@ -1,2 +1,0 @@
-[client.{{ .Values.ceph.glance_user }}]
-     key = {{ .Values.ceph.glance_keyring }}

--- a/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -5,7 +5,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combine
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
 
 <VirtualHost *:{{ .Values.network.port.public }}>
-    WSGIDaemonProcess keystone-public processes=16 threads=6 user=keystone group=keystone display-name=%{GROUP}
+    WSGIDaemonProcess keystone-public processes=1 threads=4 user=keystone group=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / /var/www/cgi-bin/keystone/main
     WSGIApplicationGroup %{GLOBAL}
@@ -21,7 +21,7 @@ LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-A
 </VirtualHost>
 
 <VirtualHost *:{{ .Values.network.port.admin }}>
-    WSGIDaemonProcess keystone-admin processes=16 threads=5 user=keystone group=keystone display-name=%{GROUP}
+    WSGIDaemonProcess keystone-admin processes=1 threads=4 user=keystone group=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-admin
     WSGIScriptAlias / /var/www/cgi-bin/keystone/admin
     WSGIApplicationGroup %{GLOBAL}


### PR DESCRIPTION
* Allow glance to support using default secrets
  if none are provided

* Resolve configmap mounting issue with glance
  ceph secrets

* Add configmap hashing to glance for consistent
   chart behavior

* Ensure keystone wsgi workers/threads are set to
  reasonable numbers for a container implementation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/129)
<!-- Reviewable:end -->
