### PR TITLE
Add support for daemonsets to the Kubernetes-Entrypoint init-container.

### DIFF
--- a/cinder/templates/deployment-api.yaml
+++ b/cinder/templates/deployment-api.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/cinder/templates/deployment-scheduler.yaml
+++ b/cinder/templates/deployment-scheduler.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/cinder/templates/deployment-volume.yaml
+++ b/cinder/templates/deployment-volume.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/cinder/templates/job-db-init.yaml
+++ b/cinder/templates/job-db-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-db-sync.yaml
+++ b/cinder/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-ks-endpoints.yaml.yaml
+++ b/cinder/templates/job-ks-endpoints.yaml.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-ks-service.yaml
+++ b/cinder/templates/job-ks-service.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-ks-user.yaml
+++ b/cinder/templates/job-ks-user.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/common/templates/_funcs.tpl
+++ b/common/templates/_funcs.tpl
@@ -21,35 +21,3 @@
 {{- $wtf := $context.Template.Name | replace $last $name -}}
 {{- include $wtf $context | sha256sum | quote -}}
 {{- end -}}
-
-{{- define "dep-check-init-cont" -}}
-{{- $envAll := index . 0 -}}
-{{- $deps := index . 1 -}}
-{
-  "name": "init",
-  "image": {{ $envAll.Values.images.dep_check | quote }},
-  "imagePullPolicy": {{ $envAll.Values.images.pull_policy | quote }},
-  "env": [
-    {
-      "name": "NAMESPACE",
-      "value": "{{ $envAll.Release.Namespace }}"
-    },
-    {
-      "name": "INTERFACE_NAME",
-      "value": "eth0"
-    },
-    {
-      "name": "DEPENDENCY_SERVICE",
-      "value": "{{  include "joinListWithColon"  $deps.service }}"
-    },
-    {
-      "name": "DEPENDENCY_JOBS",
-      "value": "{{  include "joinListWithColon" $deps.jobs }}"
-    },
-    {
-      "name": "COMMAND",
-      "value": "echo done"
-    }
-  ]
-}
-{{- end -}}

--- a/common/templates/snippets/_k8s_init_dep_check.tpl
+++ b/common/templates/snippets/_k8s_init_dep_check.tpl
@@ -1,0 +1,49 @@
+{{- define "dep_check_init_cont" -}}
+{{- $envAll := index . 0 -}}
+{{- $deps := index . 1 -}}
+{
+  "name": "init",
+  "image": {{ $envAll.Values.images.dep_check | quote }},
+  "imagePullPolicy": {{ $envAll.Values.images.pull_policy | quote }},
+  "env": [
+    {
+      "name": "POD_NAME",
+      "valueFrom": {
+        "fieldRef": {
+          "APIVersion": "v1",
+          "fieldPath": "metadata.name"
+        }
+      }
+    },
+    {
+      "name": "NAMESPACE",
+      "valueFrom": {
+        "fieldRef": {
+          "APIVersion": "v1",
+          "fieldPath": "metadata.namespace"
+        }
+      }
+    },
+    {
+      "name": "INTERFACE_NAME",
+      "value": "eth0"
+    },
+    {
+      "name": "DEPENDENCY_SERVICE",
+      "value": "{{  include "joinListWithColon"  $deps.service }}"
+    },
+    {
+      "name": "DEPENDENCY_JOBS",
+      "value": "{{  include "joinListWithColon" $deps.jobs }}"
+    },
+    {
+      "name": "DEPENDENCY_DAEMONSET",
+      "value": "{{  include "joinListWithColon" $deps.daemonset }}"
+    },
+    {
+      "name": "COMMAND",
+      "value": "echo done"
+    }
+  ]
+}
+{{- end -}}

--- a/glance/templates/deployment-api.yaml
+++ b/glance/templates/deployment-api.yaml
@@ -26,7 +26,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/glance/templates/deployment-registry.yaml
+++ b/glance/templates/deployment-registry.yaml
@@ -18,7 +18,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/glance/templates/job-db-sync.yaml
+++ b/glance/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/glance/templates/job-init.yaml
+++ b/glance/templates/job-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/glance/templates/job-post.yaml
+++ b/glance/templates/job-post.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/deployment-api.yaml
+++ b/heat/templates/deployment-api.yaml
@@ -12,7 +12,7 @@ spec:
         app: heat-api
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/deployment-cfn.yaml
+++ b/heat/templates/deployment-cfn.yaml
@@ -12,7 +12,7 @@ spec:
         app: heat-cfn
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/deployment-cloudwatch.yaml
+++ b/heat/templates/deployment-cloudwatch.yaml
@@ -12,7 +12,7 @@ spec:
         app: heat-cloudwatch
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/job-db-init.yaml
+++ b/heat/templates/job-db-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-db-sync.yaml
+++ b/heat/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-ks-endpoints.yaml.yaml
+++ b/heat/templates/job-ks-endpoints.yaml.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-ks-service.yaml
+++ b/heat/templates/job-ks-service.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-ks-user.yaml
+++ b/heat/templates/job-ks-user.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/statefulset-engine.yaml
+++ b/heat/templates/statefulset-engine.yaml
@@ -13,7 +13,7 @@ spec:
         app: heat-engine
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/horizon/templates/deployment.yaml
+++ b/horizon/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/keystone/templates/deployment.yaml
+++ b/keystone/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependecies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependecies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/keystone/templates/job-db-sync.yaml
+++ b/keystone/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependecies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependecies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/keystone/templates/job-init.yaml
+++ b/keystone/templates/job-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/nova/templates/daemonset-compute.yaml
+++ b/nova/templates/daemonset-compute.yaml
@@ -13,7 +13,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/daemonset-libvirt.yaml
+++ b/nova/templates/daemonset-libvirt.yaml
@@ -13,7 +13,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-api-metadata.yaml
+++ b/nova/templates/deployment-api-metadata.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-api-osapi.yaml
+++ b/nova/templates/deployment-api-osapi.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-conductor.yaml
+++ b/nova/templates/deployment-conductor.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-consoleauth.yaml
+++ b/nova/templates/deployment-consoleauth.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-scheduler.yaml
+++ b/nova/templates/deployment-scheduler.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/job-db-sync.yaml
+++ b/nova/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/nova/templates/job-init.yaml
+++ b/nova/templates/job-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/nova/templates/job-post.yaml
+++ b/nova/templates/job-post.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
It also makes two other changes:

 * Moves the entrypoint container manifest snippet to its own file to reduce loading on the _funcs.tpl file
 * Changes dep-check-init-cont to dep_check_init_cont to match the formatting of other defines used in OpenStack Helm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/137)
<!-- Reviewable:end -->
