### PR TITLE
Neutron: Move to use init-containers for dependency checking

### DIFF
--- a/cinder/templates/deployment-api.yaml
+++ b/cinder/templates/deployment-api.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/cinder/templates/deployment-scheduler.yaml
+++ b/cinder/templates/deployment-scheduler.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/cinder/templates/deployment-volume.yaml
+++ b/cinder/templates/deployment-volume.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/cinder/templates/job-db-init.yaml
+++ b/cinder/templates/job-db-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-db-sync.yaml
+++ b/cinder/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-ks-endpoints.yaml.yaml
+++ b/cinder/templates/job-ks-endpoints.yaml.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-ks-service.yaml
+++ b/cinder/templates/job-ks-service.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/cinder/templates/job-ks-user.yaml
+++ b/cinder/templates/job-ks-user.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/common/templates/_funcs.tpl
+++ b/common/templates/_funcs.tpl
@@ -21,35 +21,3 @@
 {{- $wtf := $context.Template.Name | replace $last $name -}}
 {{- include $wtf $context | sha256sum | quote -}}
 {{- end -}}
-
-{{- define "dep-check-init-cont" -}}
-{{- $envAll := index . 0 -}}
-{{- $deps := index . 1 -}}
-{
-  "name": "init",
-  "image": {{ $envAll.Values.images.dep_check | quote }},
-  "imagePullPolicy": {{ $envAll.Values.images.pull_policy | quote }},
-  "env": [
-    {
-      "name": "NAMESPACE",
-      "value": "{{ $envAll.Release.Namespace }}"
-    },
-    {
-      "name": "INTERFACE_NAME",
-      "value": "eth0"
-    },
-    {
-      "name": "DEPENDENCY_SERVICE",
-      "value": "{{  include "joinListWithColon"  $deps.service }}"
-    },
-    {
-      "name": "DEPENDENCY_JOBS",
-      "value": "{{  include "joinListWithColon" $deps.jobs }}"
-    },
-    {
-      "name": "COMMAND",
-      "value": "echo done"
-    }
-  ]
-}
-{{- end -}}

--- a/common/templates/snippets/_k8s_init_dep_check.tpl
+++ b/common/templates/snippets/_k8s_init_dep_check.tpl
@@ -1,0 +1,49 @@
+{{- define "dep_check_init_cont" -}}
+{{- $envAll := index . 0 -}}
+{{- $deps := index . 1 -}}
+{
+  "name": "init",
+  "image": {{ $envAll.Values.images.dep_check | quote }},
+  "imagePullPolicy": {{ $envAll.Values.images.pull_policy | quote }},
+  "env": [
+    {
+      "name": "POD_NAME",
+      "valueFrom": {
+        "fieldRef": {
+          "APIVersion": "v1",
+          "fieldPath": "metadata.name"
+        }
+      }
+    },
+    {
+      "name": "NAMESPACE",
+      "valueFrom": {
+        "fieldRef": {
+          "APIVersion": "v1",
+          "fieldPath": "metadata.namespace"
+        }
+      }
+    },
+    {
+      "name": "INTERFACE_NAME",
+      "value": "eth0"
+    },
+    {
+      "name": "DEPENDENCY_SERVICE",
+      "value": "{{  include "joinListWithColon"  $deps.service }}"
+    },
+    {
+      "name": "DEPENDENCY_JOBS",
+      "value": "{{  include "joinListWithColon" $deps.jobs }}"
+    },
+    {
+      "name": "DEPENDENCY_DAEMONSET",
+      "value": "{{  include "joinListWithColon" $deps.daemonset }}"
+    },
+    {
+      "name": "COMMAND",
+      "value": "echo done"
+    }
+  ]
+}
+{{- end -}}

--- a/glance/templates/deployment-api.yaml
+++ b/glance/templates/deployment-api.yaml
@@ -26,7 +26,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/glance/templates/deployment-registry.yaml
+++ b/glance/templates/deployment-registry.yaml
@@ -18,7 +18,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/glance/templates/job-db-sync.yaml
+++ b/glance/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/glance/templates/job-init.yaml
+++ b/glance/templates/job-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/glance/templates/job-post.yaml
+++ b/glance/templates/job-post.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/deployment-api.yaml
+++ b/heat/templates/deployment-api.yaml
@@ -12,7 +12,7 @@ spec:
         app: heat-api
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/deployment-cfn.yaml
+++ b/heat/templates/deployment-cfn.yaml
@@ -12,7 +12,7 @@ spec:
         app: heat-cfn
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/deployment-cloudwatch.yaml
+++ b/heat/templates/deployment-cloudwatch.yaml
@@ -12,7 +12,7 @@ spec:
         app: heat-cloudwatch
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/heat/templates/job-db-init.yaml
+++ b/heat/templates/job-db-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-db-sync.yaml
+++ b/heat/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-ks-endpoints.yaml.yaml
+++ b/heat/templates/job-ks-endpoints.yaml.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-ks-service.yaml
+++ b/heat/templates/job-ks-service.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/job-ks-user.yaml
+++ b/heat/templates/job-ks-user.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/heat/templates/statefulset-engine.yaml
+++ b/heat/templates/statefulset-engine.yaml
@@ -13,7 +13,7 @@ spec:
         app: heat-engine
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/horizon/templates/deployment.yaml
+++ b/horizon/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/keystone/templates/deployment.yaml
+++ b/keystone/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependecies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependecies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/keystone/templates/job-db-sync.yaml
+++ b/keystone/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependecies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependecies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/keystone/templates/job-init.yaml
+++ b/keystone/templates/job-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/neutron/templates/daemonset-dhcp-agent.yaml
+++ b/neutron/templates/daemonset-dhcp-agent.yaml
@@ -1,3 +1,5 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.dhcp }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -9,7 +11,10 @@ spec:
         app: neutron-dhcp-agent
       annotations:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
-        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       nodeSelector:
         {{ .Values.labels.agent.dhcp.node_selector_key }}: {{ .Values.labels.agent.dhcp.node_selector_value }}
@@ -23,25 +28,12 @@ spec:
           imagePullPolicy: {{ .Values.images.pull_policy }}
           securityContext:
             privileged: true
-          env:
-            - name: INTERFACE_NAME
-              value: {{ .Values.network.interface.dhcp | default .Values.network.interface.default }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "neutron-dhcp-agent --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/dhcp-agent.ini"
-            - name: DEPENDENCY_JOBS
-              value: "{{  include "joinListWithColon" .Values.dependencies.dhcp.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.dhcp.service }}"
-            - name: DEPENDENCY_DAEMONSET
-              value: "{{  include "joinListWithColon" .Values.dependencies.dhcp.daemonset }}"
+          command:
+            - neutron-dhcp-agent
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-file
+            - /etc/neutron/dhcp-agent.ini
           volumeMounts:
             - name: neutronconf
               mountPath: /etc/neutron/neutron.conf
@@ -61,7 +53,7 @@ spec:
               mountPath: /var/lib/neutron/openstack-helm
             - name: resolvconf
               mountPath: /etc/resolv.conf
-              subPath: resolv.conf              
+              subPath: resolv.conf
       volumes:
         - name: neutronconf
           configMap:

--- a/neutron/templates/daemonset-l3-agent.yaml
+++ b/neutron/templates/daemonset-l3-agent.yaml
@@ -1,3 +1,5 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.l3 }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -9,7 +11,10 @@ spec:
         app: neutron-l3-agent
       annotations:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
-        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       nodeSelector:
         {{ .Values.labels.agent.l3.node_selector_key }}: {{ .Values.labels.agent.l3.node_selector_value }}
@@ -23,25 +28,14 @@ spec:
           imagePullPolicy: {{ .Values.images.pull_policy }}
           securityContext:
             privileged: true
-          env:
-            - name: INTERFACE_NAME
-              value: {{ .Values.network.interface.l3 | default .Values.network.interface.default }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "neutron-l3-agent --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/l3-agent.ini --config-file /etc/neutron/plugins/ml2/ml2-conf.ini"
-            - name: DEPENDENCY_JOBS
-              value: "{{  include "joinListWithColon" .Values.dependencies.l3.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.l3.service }}"
-            - name: DEPENDENCY_DAEMONSET
-              value: "{{  include "joinListWithColon" .Values.dependencies.l3.daemonset }}"              
+          command:
+            - neutron-l3-agent
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-file
+            - /etc/neutron/l3-agent.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf.ini
           volumeMounts:
             - name: neutronconf
               mountPath: /etc/neutron/neutron.conf
@@ -54,7 +48,7 @@ spec:
               subPath: l3-agent.ini
             - name: resolvconf
               mountPath: /etc/resolv.conf
-              subPath: resolv.conf                 
+              subPath: resolv.conf
             - name: runopenvswitch
               mountPath: /run/openvswitch
             - name: socket

--- a/neutron/templates/daemonset-metadata-agent.yaml
+++ b/neutron/templates/daemonset-metadata-agent.yaml
@@ -1,3 +1,5 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.metadata }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -9,7 +11,10 @@ spec:
         app: neutron-metadata-agent
       annotations:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
-        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       nodeSelector:
         {{ .Values.labels.agent.metadata.node_selector_key }}: {{ .Values.labels.agent.metadata.node_selector_value }}
@@ -23,27 +28,14 @@ spec:
           imagePullPolicy: {{ .Values.images.pull_policy }}
           securityContext:
             privileged: true
-          env:
-            - name: INTERFACE_NAME
-              value: {{ .Values.network.interface.metadata | default .Values.network.interface.default }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "neutron-metadata-agent --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/metadata-agent.ini"
-            - name: DEPENDENCY_JOBS
-              value: "{{  include "joinListWithColon" .Values.dependencies.metadata.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.metadata.service }}"
-            - name: DEPENDENCY_DAEMONSET
-              value: "{{  include "joinListWithColon" .Values.dependencies.metadata.daemonset }}"              
+          command:
+            - neutron-metadata-agent
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-file
+            - /etc/neutron/metadata-agent.ini
           ports:
-          - containerPort: {{ .Values.network.port.metadata }}              
+          - containerPort: {{ .Values.network.port.metadata }}
           volumeMounts:
             - name: neutronconf
               mountPath: /etc/neutron/neutron.conf
@@ -56,7 +48,7 @@ spec:
               subPath: metadata-agent.ini
             - name: resolvconf
               mountPath: /etc/resolv.conf
-              subPath: resolv.conf              
+              subPath: resolv.conf
             - name: runopenvswitch
               mountPath: /run/openvswitch
             - name: socket
@@ -73,7 +65,7 @@ spec:
             name: neutron-etc
         - name: resolvconf
           configMap:
-            name: neutron-etc            
+            name: neutron-etc
         - name: runopenvswitch
           hostPath:
             path: /run/openvswitch

--- a/neutron/templates/daemonset-ovs-agent.yaml
+++ b/neutron/templates/daemonset-ovs-agent.yaml
@@ -1,3 +1,5 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.ovs_agent }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -9,10 +11,13 @@ spec:
         app: ovs-agent
       annotations:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
-        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       nodeSelector:
-        {{ .Values.labels.ovs.node_selector_key }}: {{ .Values.labels.ovs.node_selector_value }}    
+        {{ .Values.labels.ovs.node_selector_key }}: {{ .Values.labels.ovs.node_selector_value }}
       securityContext:
         runAsUser: 0
       dnsPolicy: ClusterFirst
@@ -23,6 +28,9 @@ spec:
           imagePullPolicy: {{ .Values.images.pull_policy }}
           securityContext:
             privileged: true
+          command:
+            - bash
+            - /tmp/neutron-openvswitch-agent.sh
           # ensures this container can can see a br-int
           # bridge before its marked as ready
           readinessProbe:
@@ -31,23 +39,6 @@ spec:
                 - bash
                 - -c
                 - 'ovs-vsctl list-br | grep -q br-int'
-          env:
-            - name: INTERFACE_NAME
-              value: {{ .Values.network.interface.openvswitch | default .Values.network.interface.default }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "bash /tmp/neutron-openvswitch-agent.sh"
-            - name: DEPENDENCY_JOBS
-              value: "{{  include "joinListWithColon" .Values.dependencies.ovs_agent.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.ovs_agent.service }}"
           volumeMounts:
             - name: neutronopenvswitchagentsh
               mountPath: /tmp/neutron-openvswitch-agent.sh
@@ -86,4 +77,4 @@ spec:
             path: /lib/modules
         - name: run
           hostPath:
-            path: /run                 
+            path: /run

--- a/neutron/templates/daemonset-ovs-db.yaml
+++ b/neutron/templates/daemonset-ovs-db.yaml
@@ -9,10 +9,10 @@ spec:
         app: ovs-db
       annotations:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
-        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
     spec:
       nodeSelector:
-        {{ .Values.labels.ovs.node_selector_key }}: {{ .Values.labels.ovs.node_selector_value }}    
+        {{ .Values.labels.ovs.node_selector_key }}: {{ .Values.labels.ovs.node_selector_value }}
       securityContext:
         runAsUser: 0
       dnsPolicy: ClusterFirst
@@ -23,19 +23,9 @@ spec:
           imagePullPolicy: {{ .Values.images.pull_policy }}
           securityContext:
             privileged: true
-          env:
-            - name: INTERFACE_NAME
-              value: {{ .Values.network.interface.openvswitch | default .Values.network.interface.default }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "bash /tmp/openvswitch-db-server.sh"
+          command:
+            - bash
+            - /tmp/openvswitch-db-server.sh
           volumeMounts:
             - name: openvswitchdbserversh
               mountPath: /tmp/openvswitch-db-server.sh
@@ -62,4 +52,3 @@ spec:
         - name: run
           hostPath:
             path: /run
-

--- a/neutron/templates/daemonset-ovs-vswitchd.yaml
+++ b/neutron/templates/daemonset-ovs-vswitchd.yaml
@@ -9,10 +9,10 @@ spec:
         app: ovs-vswitchd
       annotations:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
-        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
     spec:
       nodeSelector:
-        {{ .Values.labels.ovs.node_selector_key }}: {{ .Values.labels.ovs.node_selector_value }}    
+        {{ .Values.labels.ovs.node_selector_key }}: {{ .Values.labels.ovs.node_selector_value }}
       securityContext:
         runAsUser: 0
       dnsPolicy: ClusterFirst
@@ -30,19 +30,9 @@ spec:
               command:
                 - /usr/bin/ovs-vsctl
                 - show
-          env:
-            - name: INTERFACE_NAME
-              value: {{ .Values.network.interface.openvswitch | default .Values.network.interface.default }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "bash /tmp/openvswitch-vswitchd.sh"
+          command:
+            - bash
+            - /tmp/openvswitch-vswitchd.sh
           volumeMounts:
             - name: openvswitchvswitchdsh
               mountPath: /tmp/openvswitch-vswitchd.sh

--- a/neutron/templates/deployment-server.yaml
+++ b/neutron/templates/deployment-server.yaml
@@ -1,3 +1,5 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.server }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -11,14 +13,17 @@ spec:
     rollingUpdate:
       maxUnavailable: {{ .Values.upgrades.rolling_update.max_unavailable }}
       maxSurge: {{ .Values.upgrades.rolling_update.max_surge }}
-    {{ end }}  
+    {{ end }}
   template:
     metadata:
       labels:
         app: neutron-server
       annotations:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
-        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       nodeSelector:
         {{ .Values.labels.server.node_selector_key }}: {{ .Values.labels.server.node_selector_value }}
@@ -26,23 +31,12 @@ spec:
         - name: neutron-server
           image: {{ .Values.images.server }}
           imagePullPolicy: {{ .Values.images.pull_policy }}
-          env:
-            - name: INTERFACE_NAME
-              value: "eth0"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "neutron-server --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2-conf.ini"
-            - name: DEPENDENCY_JOBS
-              value: "{{  include "joinListWithColon" .Values.dependencies.server.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.server.service }}"
+          command:
+            - neutron-server
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf.ini
           ports:
           - containerPort: {{ .Values.network.port.server }}
           readinessProbe:

--- a/neutron/templates/job-db-sync.yaml
+++ b/neutron/templates/job-db-sync.yaml
@@ -1,9 +1,16 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.db_sync }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: neutron-db-sync
 spec:
   template:
+    metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       restartPolicy: OnFailure
       nodeSelector:
@@ -12,24 +19,17 @@ spec:
         - name: neutron-db-sync
           image: {{ .Values.images.db_sync }}
           imagePullPolicy: {{ .Values.images.pull_policy }}
-          env:
-            - name: INTERFACE_NAME
-              value: "eth0"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "neutron-db-manage --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2-conf.ini upgrade head"
-            - name: DEPENDENCY_JOBS
-              value: "{{  include "joinListWithColon" .Values.dependencies.db_sync.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.db_sync.service }}"
+          command:
+            - neutron-db-manage
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf.ini
+            - upgrade
+            - head
           volumeMounts:
+            - name: pod-etc-neutron
+              mountPath: /etc/neutron
             - name: neutronconf
               mountPath: /etc/neutron/neutron.conf
               subPath: neutron.conf
@@ -37,6 +37,8 @@ spec:
               mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
               subPath: ml2-conf.ini
       volumes:
+        - name: pod-etc-neutron
+          emptyDir: {}
         - name: neutronconf
           configMap:
             name: neutron-etc

--- a/neutron/templates/job-init.yaml
+++ b/neutron/templates/job-init.yaml
@@ -1,9 +1,16 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.db_init }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: neutron-init
 spec:
   template:
+    metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       restartPolicy: OnFailure
       nodeSelector:
@@ -12,23 +19,9 @@ spec:
         - name: neutron-init
           image: {{ .Values.images.init }}
           imagePullPolicy: {{ .Values.images.pull_policy }}
-          env:
-            - name: INTERFACE_NAME
-              value: "eth0"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "bash /tmp/init.sh"
-            - name: DEPENDENCY_JOBS
-              value: "{{  include "joinListWithColon" .Values.dependencies.init.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.init.service }}"
+          command:
+            - bash
+            - /tmp/init.sh
           volumeMounts:
             - name: initsh
               mountPath: /tmp/init.sh

--- a/neutron/templates/job-post.yaml
+++ b/neutron/templates/job-post.yaml
@@ -1,9 +1,16 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.db_sync }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: neutron-post
 spec:
   template:
+    metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
+        ]'
     spec:
       restartPolicy: OnFailure
       nodeSelector:
@@ -12,23 +19,10 @@ spec:
         - name: neutron-post
           image: {{ .Values.images.post }}
           imagePullPolicy: {{ .Values.images.pull_policy }}
+          command:
+            - bash
+            - /tmp/post.sh
           env:
-            - name: INTERFACE_NAME
-              value: "eth0"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "bash /tmp/post.sh"
-            - name: DEPENDENCY_JOBS
-              value:  "{{  include "joinListWithColon" .Values.dependencies.post.jobs }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{  include "joinListWithColon" .Values.dependencies.post.service }}"
             - name: ANSIBLE_LIBRARY
               value: /usr/share/ansible/
           volumeMounts:

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -17,7 +17,7 @@ images:
   openvswitch_db_server: quay.io/attcomdev/openvswitch-vswitchd:latest
   openvswitch_vswitchd: quay.io/attcomdev/openvswitch-vswitchd:latest
   post: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
-  entrypoint: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
   pull_policy: "IfNotPresent"
 
 upgrades:
@@ -39,7 +39,7 @@ labels:
     dhcp:
       node_selector_key: openstack-control-plane
       node_selector_value: enabled
-    l3: 
+    l3:
       node_selector_key: openstack-control-plane
       node_selector_value: enabled
     metadata:
@@ -54,7 +54,7 @@ network:
     kubernetes_domain: cluster.local
     # this must list the skydns server first, and in calico
     # this is consistently 10.96.0.10
-    servers: 
+    servers:
     - 10.96.0.10
     - 8.8.8.8
   external_bridge: br-ex
@@ -62,14 +62,14 @@ network:
   interface:
     external: enp12s0f0
     default: enp11s0f0
-  port: 
+  port:
     server: 9696
     metadata: 8775
 
-memcached: 
+memcached:
   address: "memcached:11211"
 
-rabbitmq: 
+rabbitmq:
   address: rabbitmq
   admin_user: rabbitmq
   admin_password: password
@@ -136,7 +136,7 @@ ml2:
     bridge_mappings:
       - "physnet1:br-physnet1"
 
-dependencies:  
+dependencies:
   server:
     jobs:
     - neutron-db-sync
@@ -185,10 +185,10 @@ dependencies:
     - ovs-agent
   db_sync:
     jobs:
-    - neutron-init
+    - neutron-db-init
     service:
     - mariadb
-  init:
+  db_init:
     jobs:
     - mariadb-seed
     service:
@@ -199,7 +199,7 @@ dependencies:
     jobs:
     - neutron-db-sync
 
-# typically overriden by environmental 
+# typically overriden by environmental
 # values, but should include all endpoints
 # required by this chart
 endpoints:

--- a/nova/templates/daemonset-compute.yaml
+++ b/nova/templates/daemonset-compute.yaml
@@ -13,7 +13,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/daemonset-libvirt.yaml
+++ b/nova/templates/daemonset-libvirt.yaml
@@ -13,7 +13,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-api-metadata.yaml
+++ b/nova/templates/deployment-api-metadata.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}        
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-api-osapi.yaml
+++ b/nova/templates/deployment-api-osapi.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-conductor.yaml
+++ b/nova/templates/deployment-conductor.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-consoleauth.yaml
+++ b/nova/templates/deployment-consoleauth.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/deployment-scheduler.yaml
+++ b/nova/templates/deployment-scheduler.yaml
@@ -22,7 +22,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "hash" }}
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       nodeSelector:

--- a/nova/templates/job-db-sync.yaml
+++ b/nova/templates/job-db-sync.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/nova/templates/job-init.yaml
+++ b/nova/templates/job-init.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure

--- a/nova/templates/job-post.yaml
+++ b/nova/templates/job-post.yaml
@@ -9,7 +9,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "dep-check-init-cont" | indent 10 }}
+{{ tuple $envAll $dependencies | include "dep_check_init_cont" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
Brings Neutron inline with other services, by moving the dependency checks to an init-container.

Builds on the following which should be reviewed/merged first:
 * https://github.com/att-comdev/openstack-helm/pull/137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/138)
<!-- Reviewable:end -->
