### PR TITLE
Add templates for pull requests and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!-- Thanks for filing an issue! Before submitting your issue, please answer the following questions.-->
+
+**Is this a bug report or feature request?** (choose one):
+
+<!--
+If this is a BUG REPORT, please:
+  - Fill in as much of the template as possible.  If you leave out
+    information, we may automatically close out your pull request.
+
+If this is a FEATURE REQUEST, please:
+  - Describe *in detail* the feature/behavior/change you'd like to see.
+
+Detailed responses allow our community to address your concerns in a timely manner.
+If we can't determine what you're asking for, we may close your issue.  If you feel
+we haven't adequately addressed your issue, please feel free to reopen your issue
+and explain your issue in more detail.
+-->
+
+**Kubernetes Version** (output of `kubectl version`):
+
+**Helm Client and Tiller Versions** (output of `helm version`):
+
+**Development or Deployment Environment?**:
+
+**Release Tag or Master**:
+
+**Expected Behavior**:
+
+**What Actually Happened**:
+
+**How to Reproduce the Issue** (as minimally as possible):
+
+**Any Additional Comments**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!--  
+      Thanks for contributing to OpenStack-Helm!  Please be thorough
+      when filling out your pull request. If the purpose for your pull
+      request is not clear, we may close your pull request and ask you
+      to resubmit.
+-->
+
+**What is the purpose of this pull request?**:
+
+**What issue does this pull request address?**: Fixes #
+
+**Notes for reviewers to consider**:
+
+**Specific reviewers for pull request**:


### PR DESCRIPTION
To establish standards for working on the project going forward,
this pull request adds basic templates for both pull requests and
reported issues for openstack-helm. These templates will enable
automatic labelling and reporting at a later time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/147)
<!-- Reviewable:end -->
