### PR TITLE
Update ceph ansible with some changes for the upstream.

### DIFF
--- a/ceph/templates/deployment-mds.yaml
+++ b/ceph/templates/deployment-mds.yaml
@@ -32,7 +32,7 @@ spec:
           secret:
             secretName: ceph-bootstrap-rgw-keyring
       containers:
-        - name: ceph-mon
+        - name: ceph-mds
           image: {{ .Values.images.daemon }}
           imagePullPolicy: {{ .Values.images.pull_policy }}
           ports:

--- a/ceph/templates/deployment-moncheck.yaml
+++ b/ceph/templates/deployment-moncheck.yaml
@@ -42,8 +42,8 @@ spec:
               value: MON_HEALTH
             - name: KV_TYPE
               value: k8s
-            - name: NETWORK_AUTO_DETECT
-              value: "4"
+            - name: MON_IP_AUTO_DETECT
+              value: "1"
             - name: CLUSTER
               value: ceph
           volumeMounts:

--- a/ceph/templates/deployment-rgw.yaml
+++ b/ceph/templates/deployment-rgw.yaml
@@ -16,7 +16,6 @@ spec:
         app: ceph
         daemon: rgw
     spec:
-      hostNetwork: true
       nodeSelector:
         {{ .Values.labels.node_selector_key }}: {{ .Values.labels.node_selector_value }}
       serviceAccount: default


### PR DESCRIPTION
I have been trying to bring up Openstack on Kubernetes deployed by DigitalRebar with Kargo on KVM instances.  :-) 

I have been debugging ceph bring-up and found these changes relative to upstream and they seem to work for me.  This makes it easy to see what is going on relative to upstream.

1. fix a container name
2. Fix mds networking parameters.
3. Make rgw not a host network container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/155)
<!-- Reviewable:end -->
