### PR TITLE
BUGFIX: CEPH Mons autodetection doesn't work reliably across install types

### DIFF
--- a/ceph/templates/statefulset-mon.yaml
+++ b/ceph/templates/statefulset-mon.yaml
@@ -72,10 +72,16 @@ spec:
               value: MON
             - name: KV_TYPE
               value: k8s
-            - name: NETWORK_AUTO_DETECT
-              value: "4"
             - name: CLUSTER
               value: ceph
+            - name: NETWORK_AUTO_DETECT
+              value: "0"
+            - name: CEPH_PUBLIC_NETWORK
+              value: {{ .Values.network.public | quote }}
+            - name: MON_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           volumeMounts:
             - name: ceph-conf
               mountPath: /etc/ceph

--- a/ceph/values.yaml
+++ b/ceph/values.yaml
@@ -25,6 +25,7 @@ labels:
   node_selector_value: enabled
 
 network:
+  public: "10.25.0.0/16"
   port: 
     mon: 6789
     rgw_ingress: 80

--- a/docs/installation/getting-started.md
+++ b/docs/installation/getting-started.md
@@ -262,7 +262,7 @@ Please ensure that you use ``--purge`` whenever deleting a project.
 ## Ceph Installation and Verification
 Install the first service, which is Ceph. If all instructions have been followed as mentioned above, this installation should go smoothly. Use the following command to install Ceph:
 ```
-admin@kubenode01:~$ helm install --name=ceph local/ceph --namespace=ceph
+admin@kubenode01:~$ helm install --set network.public=$osd_public_network --name=ceph local/ceph --namespace=ceph
 ```
 
 ## Bootstrap Installation


### PR DESCRIPTION
I have been trying to bring up Openstack on Kubernetes deployed by DigitalRebar with Kargo on KVM instances.  :-) 

I've found that the ceph network discovery doesn't work cleanly for all install types with Kargo (cloud vs bare metal vs calico flannel. ...).  Injecting the MON_IP and public cluster resolve the issue.  We have the information so it seems cleaner to do it this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/156)
<!-- Reviewable:end -->
