### PR TITLE
BUGFIX: Change the ceph images from the custom ATT to the ceph-docker upstream.

### DIFF
--- a/ceph/values.yaml
+++ b/ceph/values.yaml
@@ -17,7 +17,7 @@ service:
     name: ceph-mon
 
 images:
-  daemon: ceph/daemon:latest
+  daemon: docker.io/library/ceph/daemon:tag-build-master-jewel-ubuntu-16.04
   pull_policy: IfNotPresent
 
 labels:

--- a/ceph/values.yaml
+++ b/ceph/values.yaml
@@ -17,7 +17,7 @@ service:
     name: ceph-mon
 
 images:
-  daemon: quay.io/attcomdev/ceph-daemon:latest
+  daemon: ceph/daemon:latest
   pull_policy: IfNotPresent
 
 labels:


### PR DESCRIPTION
I have been trying to bring up Openstack on Kubernetes deployed by DigitalRebar with Kargo on KVM instances.  :-) 

The ATT produced ceph image alway seemed to hang for me.  Switching to the ceph provided docker image seemed to work better for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/157)
<!-- Reviewable:end -->
