### PR TITLE
Allow CEPH OSD to use devices on the systems through

### DIFF
--- a/ceph/templates/daemonset-osd.yaml
+++ b/ceph/templates/daemonset-osd.yaml
@@ -60,7 +60,14 @@ spec:
             privileged: true
           env:
             - name: CEPH_DAEMON
-              value: osd_directory
+              value: {{ .Values.osd.daemon }}
+            # Type, Disks, and Zap are ignored for directory-based OSDs.
+            - name: OSD_TYPE
+              value: {{ .Values.osd.type }}
+            - name: OSD_DISKS
+              value: {{ .Values.osd.disks | quote }}
+            - name: OSD_FORCE_ZAP
+              value: {{ .Values.osd.zap | quote }}
             - name: KV_TYPE
               value: k8s
             - name: CLUSTER

--- a/ceph/values.yaml
+++ b/ceph/values.yaml
@@ -30,6 +30,13 @@ network:
     rgw_ingress: 80
     rgw_target: 8088
 
+osd:
+  # Change to osd to use reall disks and set zap to 1
+  daemon: osd_directory
+  type: devices
+  disks: "0:sdb 1:sdc 2:sdd 3:sde"
+  zap: "0"
+
 storage:
   osd_directory: /var/lib/openstack-helm/ceph/osd
   var_directory: /var/lib/openstack-helm/ceph/ceph

--- a/docs/installation/getting-started.md
+++ b/docs/installation/getting-started.md
@@ -265,6 +265,13 @@ Install the first service, which is Ceph. If all instructions have been followed
 admin@kubenode01:~$ helm install --name=ceph local/ceph --namespace=ceph
 ```
 
+By default, ceph will be installed with the system using the space in a host mounted directory.  This can
+be overridden by adding additional set parameters.  This will tell each osd to use physical disks
+/dev/sdb and /dev/sdc as drives.
+```
+admin@kubenode01:~$ helm install --set network.public=$osd_public_network,osd.daemon="osd",osd.zap="1",ods.disks="0:sdb 1:sdc" --name=ceph local/ceph --namespace=ceph
+```
+
 ## Bootstrap Installation
 At this time (and before verification of Ceph) you'll need to install the `bootstrap` chart. The `bootstrap` chart will install secrets for both the `ceph` and `openstack` namespaces for the general StorageClass:
 ```


### PR DESCRIPTION
I have been trying to bring up Openstack on Kubernetes deployed by DigitalRebar with Kargo on KVM instances.  :-) 

On my KVM systems, I have "real" disks attached for ceph consumption.  These changes all the current defaults to be maintained, but real disks can be injected into the configuration.  It assumes system homogeneity but it is a start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/openstack-helm/158)
<!-- Reviewable:end -->
