### PR TITLE
Add travis-ci to openstack-helm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: go
+
+services:
+  - docker
+  
+before_install:
+  - export GLIDE_VERSION=v0.12.3
+  - ls $GOPATH/src/
+  - wget "https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz"
+  - mkdir -p $HOME/bin
+  - tar -vxz -C $HOME/bin --strip=1 -f glide-$GLIDE_VERSION-linux-amd64.tar.gz
+  - export PATH="$HOME/bin:$PATH" GLIDE_HOME="$HOME/.glide"
+
+install:
+  - cd $GOPATH/src/
+  - mkdir k8s.io && cd k8s.io
+  - git clone https://github.com/kubernetes/helm
+  - cd helm && make bootstrap build
+  - mv bin/helm $HOME/bin
+
+script:
+  - cd $TRAVIS_BUILD_DIR
+  - bash travis-ci/kubeadm_setup.sh  
+  - $HOME/gopath/src/k8s.io/helm/bin/tiller &
+  - export HELM_HOST=localhost:44134
+  - helm init --client-only
+  - helm version
+  - helm serve &
+  - sleep 1m
+  - helm repo add local http://localhost:8879/charts
+  - helm repo update
+  - make
+  - bash travis-ci/charts_dry_run.sh

--- a/travis-ci/charts_dry_run.sh
+++ b/travis-ci/charts_dry_run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for chart in *.tgz; do
+  echo "Running helm install --dry-run --debug on $chart";
+  helm install --dry-run --debug local/$chart;
+done

--- a/travis-ci/kubeadm_setup.sh
+++ b/travis-ci/kubeadm_setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run -it -e quay.io/attcomdev/kubeadm-ci:latest --name kubeadm-ci --privileged=true -d --net=host --security-opt seccomp:unconfined --cap-add=SYS_ADMIN -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /var/run/docker.sock:/var/run/docker.sock quay.io/attcomdev/kubeadm-ci:latest /sbin/init
+
+docker exec kubeadm-ci kubeadm.sh

--- a/travis-ci/kubeadm_setup.sh
+++ b/travis-ci/kubeadm_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker run -it -e quay.io/attcomdev/kubeadm-ci:latest --name kubeadm-ci --privileged=true -d --net=host --security-opt seccomp:unconfined --cap-add=SYS_ADMIN -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /var/run/docker.sock:/var/run/docker.sock quay.io/attcomdev/kubeadm-ci:latest /sbin/init
+docker run -it -e quay.io/attcomdev/kubeadm-ci:v1.1.0 --name kubeadm-ci --privileged=true -d --net=host --security-opt seccomp:unconfined --cap-add=SYS_ADMIN -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /var/run/docker.sock:/var/run/docker.sock quay.io/attcomdev/kubeadm-ci:v1.1.0 /sbin/init
 
 docker exec kubeadm-ci kubeadm.sh


### PR DESCRIPTION
Adds the travis.yml file to openstack-helm. The current travis
workflow is: install glide for helm, build helm from source,
run kubeadm in a container, init helm on the client side, then run
tiller locally. The scripts currently run the makefile to
check: helm dep up, helm lint, and helm package on the charts
defined in the makefile. Then a helm install --dry-run debug is
run on each of the charts packaged locally.

<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**:  This pull request adds the .travis.yml file to openstack-helm, allowing us to leverage TravisCI for the repository.  It also includes a travis-ci/ directory for housing additional scripts we may want to run as part of the TravisCI jobs.  This will require an administrator to set up TravisCI as an integration on the repository.

**What issue does this pull request address?**: Fixes #144 

**Notes for reviewers to consider**:  The current approach is to leverage the Makefile in the repo for checking: `helm dep up`, `helm lint`, and `helm package`.  We can break these out if necessary.  Also, building and running Tiller from source locally was necessary in order to run jobs that Tiller is required for, such as `helm install --dry-run --debug`.  This approach actually lends us flexibility, because we can then point the locally built Tiller to an external Kubernetes cluster and offload that work instead of trying to run it inside TravisCI.

**Specific reviewers for pull request**: @v1k0d3n @alanmeadows @js5175 @nadeemanwar 
