### PR TITLE
Fix path for Tiller instance in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 script:
   - cd $TRAVIS_BUILD_DIR
   - bash travis-ci/kubeadm_setup.sh  
-  - $HOME/gopath/src/k8s.io/helm/bin/tiller &
+  - $GOPATH/src/k8s.io/helm/bin/tiller &
   - export HELM_HOST=localhost:44134
   - helm init --client-only
   - helm version


### PR DESCRIPTION
Overlooked an issue with the path for running Tiller locally.
Should be $GOPATH instead of $HOME/gopath

<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: To address an issue with the path for Tiller running in TravisCI

**What issue does this pull request address?**: N/A

**Notes for reviewers to consider**:

**Specific reviewers for pull request**: @v1k0d3n 
