### PR TITLE
Fixed copyright headers for rabbitmq erlang templates

### DIFF
--- a/rabbitmq/templates/etc/_enabled_plugins.tpl
+++ b/rabbitmq/templates/etc/_enabled_plugins.tpl
@@ -1,15 +1,15 @@
-# Copyright 2017 The Openstack-Helm Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+% Copyright 2017 The Openstack-Helm Authors.
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%     http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
 
 [{{ include "helm-toolkit.joinListWithComma" .Values.enabled_plugins }}].

--- a/rabbitmq/templates/etc/_erlang.cookie.tpl
+++ b/rabbitmq/templates/etc/_erlang.cookie.tpl
@@ -1,15 +1,1 @@
-# Copyright 2017 The Openstack-Helm Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{ .Values.erlang_cookie }}

--- a/rabbitmq/templates/etc/_rabbitmq.config.tpl
+++ b/rabbitmq/templates/etc/_rabbitmq.config.tpl
@@ -1,16 +1,16 @@
-# Copyright 2017 The Openstack-Helm Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+% Copyright 2017 The Openstack-Helm Authors.
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%     http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
 
 [
    {rabbit, [


### PR DESCRIPTION
<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**:
To convert the copyright headers on the rabbitmq erlang templates to erlang-style comments, and remove the header from the cookie file.

**What issue does this pull request address?**: Fixes #237 

**Notes for reviewers to consider**:

**Specific reviewers for pull request**: jallirs
