### PR TITLE
maas cannot parse header in secret file

### DIFF
--- a/maas/templates/etc/_secret.tpl
+++ b/maas/templates/etc/_secret.tpl
@@ -1,15 +1,1 @@
-# Copyright 2017 The Openstack-Helm Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{ .Values.secret }}


### PR DESCRIPTION
<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**:
MaaS throws exceptions due to the apache header in it's secret file.

**What issue does this pull request address?**: Fixes #
https://github.com/att-comdev/openstack-helm/issues/241

**Notes for reviewers to consider**:
n/a

**Specific reviewers for pull request**:
@v1k0d3n @alanmeadows @wilkers-steve 