### PR TITLE
bug: single rabbitmq instances don't need cluster readiness checks

### DIFF
--- a/rabbitmq/templates/bin/_rabbitmq-readiness.sh.tpl
+++ b/rabbitmq/templates/bin/_rabbitmq-readiness.sh.tpl
@@ -33,7 +33,7 @@ main() {
         return 1
     fi
 
-    {{ if gt ".Values.replicas" "1" -}}
+    {{ if gt (.Values.replicas | int) 1 -}}
     if ! is-node-properly-clustered; then
         log-it "Node is inconsistent with the rest of the cluster"
         return 1

--- a/rabbitmq/templates/bin/_rabbitmq-readiness.sh.tpl
+++ b/rabbitmq/templates/bin/_rabbitmq-readiness.sh.tpl
@@ -32,10 +32,13 @@ main() {
         log-it "Node is unhealthy"
         return 1
     fi
+
+    {{ if gt ".Values.replicas" "1" -}}
     if ! is-node-properly-clustered; then
         log-it "Node is inconsistent with the rest of the cluster"
         return 1
     fi
+    {{- end }}
     return 0
 }
 


### PR DESCRIPTION
For single instance environments we're using the following overrides on the rabbitmq chart. It also avoids the extra etcd dependency.

```
auth:
  default_user: rabbitmq
dependencies:
  service:
enabled_plugins:
images:
  pull_policy: Always
replicas: 1
```

Unfortunately, the cluster readiness probe still runs every 10 seconds. The error is not fatal but is extremely noisy.

```
07:01:07 [readiness:4188] Starting readiness probe at 2017-03-13 21:57:39
07:01:07 [readiness:4188] Unexpected health-check output, giving the node the benefit of the doubt
07:01:07 [readiness:4188] Error: {{badmatch,{error,"Backend is not configured"}},
07:01:07 [readiness:4188]         [{autocluster,with_startup_lock,1,
07:01:07 [readiness:4188]                       [{file,"src/autocluster.erl"},{line,564}]},
07:01:07 [readiness:4188]          {autocluster,cluster_health_check_report,0,
07:01:07 [readiness:4188]                       [{file,"src/autocluster.erl"},{line,632}]},
07:01:07 [readiness:4188]          {autocluster,cluster_health_check,0,
07:01:07 [readiness:4188]                       [{file,"src/autocluster.erl"},{line,627}]},
07:01:07 [readiness:4188]          {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,670}]},
07:01:07 [readiness:4188]          {rpc,'-handle_call_call/6-fun-0-',5,[{file,"rpc.erl"},{line,187}]}]}
07:01:07 [readiness:4188] Ready to return 0
07:01:07 [readiness:4685] Starting readiness probe at 2017-03-13 21:57:49
07:01:07 [readiness:4685] Unexpected health-check output, giving the node the benefit of the doubt
07:01:07 [readiness:4685] Error: {{badmatch,{error,"Backend is not configured"}},
07:01:07 [readiness:4685]         [{autocluster,with_startup_lock,1,
07:01:07 [readiness:4685]                       [{file,"src/autocluster.erl"},{line,564}]},
07:01:07 [readiness:4685]          {autocluster,cluster_health_check_report,0,
07:01:07 [readiness:4685]                       [{file,"src/autocluster.erl"},{line,632}]},
07:01:07 [readiness:4685]          {autocluster,cluster_health_check,0,
07:01:07 [readiness:4685]                       [{file,"src/autocluster.erl"},{line,627}]},
07:01:07 [readiness:4685]          {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,670}]},
07:01:07 [readiness:4685]          {rpc,'-handle_call_call/6-fun-0-',5,[{file,"rpc.erl"},{line,187}]}]}
07:01:07 [readiness:4685] Ready to return 0
```