### PR TITLE
Fix horizon endpoints keys in values.yaml

### DIFF
--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -68,7 +68,7 @@ resources:
 # values, but should include all endpoints
 # required by this chart
 endpoints:
-    identity:
+  identity:
     name: keystone
     hosts:
       default: keystone-api


### PR DESCRIPTION
<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: Fixes the indentation in the Keystone Endpoints specification in values.yaml

**What issue does this pull request address?**: Fixes https://github.com/att-comdev/openstack-helm/issues/278

**Notes for reviewers to consider**:

This is a trivial-fix but is required for Horizon to operate as desired.

**Specific reviewers for pull request**:
@wilkers-steve @v1k0d3n 