### PR TITLE
bug: Add missing template for nova configmap-etc

### DIFF
--- a/nova/templates/etc/_ceph.client.cinder.keyring.yaml.tpl
+++ b/nova/templates/etc/_ceph.client.cinder.keyring.yaml.tpl
@@ -1,0 +1,20 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[client.{{ .Values.ceph.cinder_user }}]
+{{- if .Values.ceph.cinder_keyring }}
+    key = {{ .Values.ceph.cinder_keyring }}
+{{- else }}
+    key = {{- include "secrets/ceph-client-key" . -}}
+{{- end }}


### PR DESCRIPTION
The ceph client cinder keyring template was missing from nova's
etc templates. This simply adds it in for the nova configmap to
consume

<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: Adds the missing ceph client cinder keyring template for nova

**What issue does this pull request address?**: Fixes #230 

**Notes for reviewers to consider**:

**Specific reviewers for pull request**: @intlabs @larryrensing @v1k0d3n
