### PR TITLE
Improve neutron chart with vxlan support.

### DIFF
--- a/neutron/templates/etc/_ml2-conf.ini.tpl
+++ b/neutron/templates/etc/_ml2-conf.ini.tpl
@@ -17,7 +17,7 @@
 type_drivers = {{ include "helm-toolkit.joinListWithComma" .Values.ml2.type_drivers }}
 tenant_network_types = {{ .Values.ml2.tenant_network_types }}
 mechanism_drivers = {{ include "helm-toolkit.joinListWithComma" .Values.ml2.mechanism_drivers }}
-extension_drivers = {{ include "joinListWithComma" .Values.ml2.extension_drivers }}
+extension_drivers = {{ include "helm-toolkit.joinListWithComma" .Values.ml2.extension_drivers }}
 
 [ml2_type_flat]
 flat_networks = {{ include "helm-toolkit.joinListWithComma" .Values.ml2.ml2_type_flat.flat_networks }}

--- a/neutron/templates/etc/_ml2-conf.ini.tpl
+++ b/neutron/templates/etc/_ml2-conf.ini.tpl
@@ -17,6 +17,7 @@
 type_drivers = {{ include "helm-toolkit.joinListWithComma" .Values.ml2.type_drivers }}
 tenant_network_types = {{ .Values.ml2.tenant_network_types }}
 mechanism_drivers = {{ include "helm-toolkit.joinListWithComma" .Values.ml2.mechanism_drivers }}
+extension_drivers = {{ include "joinListWithComma" .Values.ml2.extension_drivers }}
 
 [ml2_type_flat]
 flat_networks = {{ include "helm-toolkit.joinListWithComma" .Values.ml2.ml2_type_flat.flat_networks }}

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -135,14 +135,18 @@ metadata:
   workers: 4
 
 ml2:
-  tenant_network_types: "flat"
+  tenant_network_types: "vxlan"
   agent:
-    tunnel_types: null
+    tunnel_types: "vxlan"
   type_drivers:
     - flat
+    - vlan
+    - vxlan
   mechanism_drivers:
     - openvswitch
     - l2population
+  extension_drivers:
+    - port_security
   ml2_type_vxlan:
     vni_ranges: "1:1000"
     vxlan_group: 239.1.1.1

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -135,7 +135,7 @@ metadata:
   workers: 4
 
 ml2:
-  tenant_network_types: "vxlan"
+  tenant_network_types: "flat"
   agent:
     tunnel_types: "vxlan"
   type_drivers:


### PR DESCRIPTION
Added VLAN and VXLAN as possible tenant networking options.
Also, changed default tenant network type to VXLAN.
Creation of flat networking is still possible.

<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**:
Improve neutron chart 
**What issue does this pull request address?**: Fixes #
Add VLAN and VXLAN tenant network creation.
**Notes for reviewers to consider**:
VXLAN tenant networks will be created as default. Other types need to be explicitly declared when creating network from CLI.
**Specific reviewers for pull request**:
