### PR TITLE
bug: update kubernetes-entrypoint version required for k8s >1.5

### DIFF
--- a/cinder/values.yaml
+++ b/cinder/values.yaml
@@ -27,7 +27,7 @@ labels:
   node_selector_value: enabled
 
 images:
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   ks_user: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   ks_service: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   ks_endpoints: quay.io/stackanetes/stackanetes-kolla-toolbox:newton

--- a/docs/helm_overrides.md
+++ b/docs/helm_overrides.md
@@ -139,7 +139,7 @@ An illustrative example of an `images:` section taken from the heat chart:
 
 ```
 images:
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   db_init: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   db_sync: docker.io/kolla/ubuntu-source-heat-api:3.0.1
   ks_user: quay.io/stackanetes/stackanetes-kolla-toolbox:newton

--- a/glance/values.yaml
+++ b/glance/values.yaml
@@ -37,7 +37,7 @@ images:
   ks_endpoints: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   api: quay.io/stackanetes/stackanetes-glance-api:newton
   registry: quay.io/stackanetes/stackanetes-glance-registry:newton
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   pull_policy: "IfNotPresent"
 
 upgrades:

--- a/heat/values.yaml
+++ b/heat/values.yaml
@@ -29,7 +29,7 @@ labels:
   node_selector_value: enabled
 
 images:
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   db_init: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   db_sync: docker.io/kolla/ubuntu-source-heat-api:3.0.1
   ks_user: quay.io/stackanetes/stackanetes-kolla-toolbox:newton

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -20,7 +20,7 @@
 replicas: 1
 
 images:
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   horizon: quay.io/stackanetes/stackanetes-horizon:newton
   pull_policy: "IfNotPresent"
 

--- a/keystone/values.yaml
+++ b/keystone/values.yaml
@@ -27,7 +27,7 @@ images:
   db_init: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   db_sync: quay.io/stackanetes/stackanetes-keystone-api:newton
   api: quay.io/stackanetes/stackanetes-keystone-api:newton
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   pull_policy: "IfNotPresent"
 
 upgrades:

--- a/maas/values.yaml
+++ b/maas/values.yaml
@@ -39,7 +39,7 @@ dependencies:
 images:
   maas_region: quay.io/attcomdev/maas-region:2.1.2-2
   maas_rack: quay.io/attcomdev/maas-rack:2.1.2-2
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   pull_policy: Always
 
 jobs:

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -33,7 +33,7 @@ images:
   neutron_openvswitch_agent: quay.io/stackanetes/stackanetes-neutron-openvswitch-agent:newton
   openvswitch_db_server: quay.io/attcomdev/openvswitch-vswitchd:latest
   openvswitch_vswitchd: quay.io/attcomdev/openvswitch-vswitchd:latest
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   pull_policy: "IfNotPresent"
 
 upgrades:

--- a/nova/values.yaml
+++ b/nova/values.yaml
@@ -39,7 +39,7 @@ images:
   consoleauth: quay.io/stackanetes/stackanetes-nova-consoleauth:newton
   compute: quay.io/stackanetes/stackanetes-nova-compute:newton
   libvirt: quay.io/stackanetes/stackanetes-nova-libvirt:newton
-  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.1
   pull_policy: "IfNotPresent"
 
 upgrades:


### PR DESCRIPTION
<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: Updates the kubernetes-entrypoint version to 0.1.1

**What issue does this pull request address?**: Fixes https://github.com/att-comdev/openstack-helm/issues/195

**Notes for reviewers to consider**:
None

**Specific reviewers for pull request**:
@alanmeadows @DTadrzak @v1k0d3n 