### PR TITLE
bug: Fix default RabbitMQ Credentials

### DIFF
--- a/rabbitmq/values.yaml
+++ b/rabbitmq/values.yaml
@@ -32,7 +32,7 @@ resources:
 labels:
   node_selector_key: openstack-control-plane
   node_selector_value: enabled
-  
+
 upgrades:
   revision_history: 3
   pod_replacement_strategy: RollingUpdate
@@ -40,9 +40,9 @@ upgrades:
     max_unavailable: 1
     max_surge: 3
 auth:
-  default_user: openstack
+  default_user: rabbitmq
   default_pass: password
-  admin_user: rabbitmq
+  admin_user: admin
   admin_pass: password
 
 network:


### PR DESCRIPTION
<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: To correct the default RabbitMQ credentials in the RabbitMQ Chart to match other OpenStack-Helm Charts

**What issue does this pull request address?**: Fixes https://github.com/att-comdev/openstack-helm/issues/239

**Notes for reviewers to consider**:
This is just a short term fix to allow OpenStack-Helm to be deployed until a path forward from https://github.com/att-comdev/openstack-helm/issues/246 is determined.

**Specific reviewers for pull request**:
@mattmceuen @wilkers-steve @v1k0d3n 