### PR TITLE
fixes #311: Glance ceph.enabled has no effect

### DIFF
--- a/glance/templates/etc/_glance-api.conf.tpl
+++ b/glance/templates/etc/_glance-api.conf.tpl
@@ -46,7 +46,7 @@ driver = noop
 
 [glance_store]
 filesystem_store_datadir = /var/lib/glance/images/
-{{- if .Values.development.enabled }}
+{{- if or (.Values.development.enabled) (not .Values.ceph.enabled) }}
 stores = file, http
 default_store = file
 {{- else }}


### PR DESCRIPTION
**What is the purpose of this pull request?**:
Fixing ceph.enabled having no effect on glance-api.conf and causing any image upload to fail without Ceph.

**What issue does this pull request address?**: Fixes #311 

**Notes for reviewers to consider**:

**Specific reviewers for pull request**:
