### PR TITLE
Add NodePort to remainder of services

### DIFF
--- a/cinder/templates/deployment-api.yaml
+++ b/cinder/templates/deployment-api.yaml
@@ -60,10 +60,10 @@ spec:
           - /etc/cinder/conf
           ports:
             - name: c-api
-              containerPort: {{ .Values.network.port.api }}
+              containerPort: {{ .Values.network.api.port }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.network.port.api }}
+              port: {{ .Values.network.api.port }}
           volumeMounts:
             - name: pod-etc-cinder
               mountPath: /etc/cinder

--- a/cinder/templates/etc/_cinder.conf.tpl
+++ b/cinder/templates/etc/_cinder.conf.tpl
@@ -22,7 +22,7 @@ volume_name_template = %s
 
 osapi_volume_workers = {{ .Values.api.workers }}
 osapi_volume_listen = 0.0.0.0
-osapi_volume_listen_port = {{ .Values.network.port.api }}
+osapi_volume_listen_port = {{ .Values.network.api.port }}
 
 api_paste_config = /etc/cinder/api-paste.ini
 

--- a/cinder/templates/service-api.yaml
+++ b/cinder/templates/service-api.yaml
@@ -18,6 +18,12 @@ metadata:
   name: cinder-api
 spec:
   ports:
-    - port: {{ .Values.network.port.api }}
+    - port: {{ .Values.network.api.port }}
+    {{ if .Values.network.api.node_port.enabled }}
+      nodePort: {{ .Values.network.api.node_port.port }}
+    {{ end }}
   selector:
     app: cinder-api
+  {{ if .Values.network.api.node_port.enabled }}
+  type: NodePort
+  {{ end }}

--- a/cinder/values.yaml
+++ b/cinder/values.yaml
@@ -62,8 +62,12 @@ keystone:
   cinder_region_name: "RegionOne"
 
 network:
-  port:
-    api: 8776
+  api:
+    name: "cinder-api"
+    port: 8776
+    node_port:
+      enabled: false
+      port: 30877
 
 database:
   address: mariadb

--- a/glance/templates/deployment-api.yaml
+++ b/glance/templates/deployment-api.yaml
@@ -63,10 +63,10 @@ spec:
           - --config-file
           - /etc/glance/glance-api.conf
           ports:
-            - containerPort: {{ .Values.network.port.api }}
+            - containerPort: {{ .Values.network.api.port }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.network.port.api }}
+              port: {{ .Values.network.api.port }}
           volumeMounts:
             - name: etcglance
               mountPath: /etc/glance

--- a/glance/templates/deployment-registry.yaml
+++ b/glance/templates/deployment-registry.yaml
@@ -55,10 +55,10 @@ spec:
           - --config-file
           - /etc/glance/glance-registry.conf
           ports:
-            - containerPort: {{ .Values.network.port.registry }}
+            - containerPort: {{ .Values.network.registry.port }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.network.port.registry }}
+              port: {{ .Values.network.registry.port }}
           volumeMounts:
             - name: etcglance
               mountPath: /etc/glance

--- a/glance/templates/etc/_glance-api.conf.tpl
+++ b/glance/templates/etc/_glance-api.conf.tpl
@@ -17,7 +17,7 @@ debug = {{ .Values.misc.debug }}
 use_syslog = False
 use_stderr = True
 
-bind_port = {{ .Values.network.port.api }}
+bind_port = {{ .Values.network.api.port }}
 workers = {{ .Values.misc.workers }}
 registry_host = glance-registry
 # Enable Copy-on-Write

--- a/glance/templates/etc/_glance-registry.conf.tpl
+++ b/glance/templates/etc/_glance-registry.conf.tpl
@@ -17,7 +17,7 @@ debug = {{ .Values.misc.debug }}
 use_syslog = False
 use_stderr = True
 
-bind_port = {{ .Values.network.port.registry }}
+bind_port = {{ .Values.network.registry.port }}
 workers = {{ .Values.misc.workers }}
 
 [database]

--- a/glance/templates/service-api.yaml
+++ b/glance/templates/service-api.yaml
@@ -18,6 +18,12 @@ metadata:
   name: glance-api
 spec:
   ports:
-    - port: {{ .Values.network.port.api }}
+    - port: {{ .Values.network.api.port }}
+    {{ if .Values.network.api.node_port.enabled }}
+      nodePort: .Values.network.api.node_port.port
+    {{ end }}
   selector:
     app: glance-api
+  {{ if .Values.network.api.node_port.enabled }}
+  type: NodePort
+  {{ end }}

--- a/glance/templates/service-registry.yaml
+++ b/glance/templates/service-registry.yaml
@@ -18,6 +18,12 @@ metadata:
   name: glance-registry
 spec:
   ports:
-    - port: {{ .Values.network.port.registry }}
+    - port: {{ .Values.network.registry.port }}
+    {{ if .Values.network.registry.node_port.enabled }}
+      nodePort: {{ .Values.network.register.node_port.port }}
+    {{ end }}
   selector:
     app: glance-registry
+  {{ if .Values.network.registry.node_port.enabled }}
+  type: NodePort
+  {{ end }}

--- a/glance/values.yaml
+++ b/glance/values.yaml
@@ -64,9 +64,18 @@ keystone:
   glance_region_name: "RegionOne"
 
 network:
-  port:
-    api: 9292
-    registry: 9191
+  api:
+    name: "glance-api"
+    port: 9292
+    node_port:
+      enabled: false
+      port: 30092
+  registry:
+    name: "glance-registry"
+    port: 9191
+    node_port:
+      enabled: false
+      port: 30091
 
 database:
   address: mariadb

--- a/keystone/templates/deployment.yaml
+++ b/keystone/templates/deployment.yaml
@@ -61,9 +61,9 @@ spec:
             - /tmp/start.sh
           ports:
             - name: api-public
-              containerPort: {{ .Values.network.port.api }}
+              containerPort: {{ .Values.network.api.port }}
             - name: api-admin
-              containerPort: {{ .Values.network.port.admin }}
+              containerPort: {{ .Values.network.admin.port }}
           lifecycle:
             preStop:
               exec:
@@ -73,7 +73,7 @@ spec:
                   - graceful-stop
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.network.port.api }}
+              port: {{ .Values.network.api.port }}
           volumeMounts:            
 {{ toYaml $mounts_keystone_api.volumeMounts | indent 12 }}
       volumes:

--- a/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Listen 0.0.0.0:{{ .Values.network.port.api }}
-Listen 0.0.0.0:{{ .Values.network.port.admin }}
+Listen 0.0.0.0:{{ .Values.network.api.port }}
+Listen 0.0.0.0:{{ .Values.network.admin.port }}
 
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
 
-<VirtualHost *:{{ .Values.network.port.api }}>
+<VirtualHost *:{{ .Values.network.api.port }}>
     WSGIDaemonProcess keystone-public processes=1 threads=4 user=keystone group=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / /var/www/cgi-bin/keystone/main
@@ -34,7 +34,7 @@ LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-A
     CustomLog /dev/stdout proxy env=forwarded
 </VirtualHost>
 
-<VirtualHost *:{{ .Values.network.port.admin }}>
+<VirtualHost *:{{ .Values.network.admin.port }}>
     WSGIDaemonProcess keystone-admin processes=1 threads=4 user=keystone group=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-admin
     WSGIScriptAlias / /var/www/cgi-bin/keystone/admin

--- a/keystone/templates/service.yaml
+++ b/keystone/templates/service.yaml
@@ -19,8 +19,18 @@ metadata:
 spec:
   ports:
   - name: keystone-api-public
-    port: {{ .Values.network.port.api }}
+    port: {{ .Values.network.api.port }}
+    {{ if .Values.network.api.node_port.enabled }}
+      nodePort: {{ .Values.network.api.node_port.port }}
+    {{ end }}
   - name: keystone-api-admin
-    port: {{ .Values.network.port.admin }}
+    port: {{ .Values.network.admin.port }}
+    {{ if .Values.network.admin.node_port.enabled }}
+      nodePort: {{ .Values.network.admin.node_port.port }}
+    {{ end }}
   selector:
     app: keystone-api
+  {{ if .Values.network.api.node_port.enabled or
+        .Values.network.admin.node_port.enabled}}
+  type: NodePort
+  {{ end }}

--- a/keystone/values.yaml
+++ b/keystone/values.yaml
@@ -46,9 +46,18 @@ keystone:
   admin_project_name: admin
 
 network:
-  port:
-    admin: 35357
-    api: 5000
+  api:
+    name: "keystone-api"
+    port: 5000
+    node_port:
+      enabled: false
+      port: 30500
+  admin:
+    name: "keystone-admin"
+    port: 35357
+    node_port:
+      enabled: false
+      port: 30357
 
 dependencies:
   api:

--- a/neutron/templates/daemonset-metadata-agent.yaml
+++ b/neutron/templates/daemonset-metadata-agent.yaml
@@ -58,7 +58,7 @@ spec:
             - --config-file
             - /etc/neutron/metadata-agent.ini
           ports:
-          - containerPort: {{ .Values.network.port.metadata }}
+          - containerPort: {{ .Values.network.metadata.port }}
           volumeMounts:
             - name: neutronconf
               mountPath: /etc/neutron/neutron.conf

--- a/neutron/templates/deployment-server.yaml
+++ b/neutron/templates/deployment-server.yaml
@@ -61,10 +61,10 @@ spec:
               memory: {{ .Values.resources.server.requests.memory | quote }}
           {{- end }}
           ports:
-          - containerPort: {{ .Values.network.port.server }}
+          - containerPort: {{ .Values.network.server.port }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.network.port.server }}
+              port: {{ .Values.network.server.port }}
           volumeMounts:
             - name: neutronconf
               mountPath: /etc/neutron/neutron.conf

--- a/neutron/templates/etc/_metadata-agent.ini.tpl
+++ b/neutron/templates/etc/_metadata-agent.ini.tpl
@@ -28,13 +28,13 @@ endpoint_type = adminURL
 
 # Nova metadata service IP and port
 nova_metadata_ip = {{ include "helm-toolkit.nova_metadata_host" . }}
-nova_metadata_port = {{ .Values.network.port.metadata }}
+nova_metadata_port = {{ .Values.network.metadata.port }}
 nova_metadata_protocol = http
 
 # Metadata proxy shared secret
 metadata_proxy_shared_secret = {{ .Values.neutron.metadata_secret }}
 
-metadata_port = {{ .Values.network.port.metadata }}
+metadata_port = {{ .Values.network.metadata.port }}
 
 # Workers and backlog requests
 metadata_workers = {{ .Values.metadata.workers }}

--- a/neutron/templates/etc/_neutron.conf.tpl
+++ b/neutron/templates/etc/_neutron.conf.tpl
@@ -18,7 +18,7 @@ use_syslog = False
 use_stderr = True
 
 bind_host = {{ .Values.network.ip_address }}
-bind_port = {{ .Values.network.port.server }}
+bind_port = {{ .Values.network.server.port }}
 
 #lock_path = /var/lock/neutron
 api_paste_config = /usr/share/neutron/api-paste.ini

--- a/neutron/templates/service.yaml
+++ b/neutron/templates/service.yaml
@@ -18,6 +18,12 @@ metadata:
   name: neutron-server
 spec:
   ports:
-    - port: {{ .Values.network.port.server }}
+    - port: {{ .Values.network.server.port }}
+    {{ if .Values.network.server.node_port.enabled }}
+      nodePort: {{ .Values.network.server.node_port.port }}
+    {{ end }}
   selector:
     app: neutron-server
+  {{ if .Values.network.server.node_port.enabled }}
+  type: NodePort
+  {{ end }}

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -78,9 +78,15 @@ network:
   interface:
     external: enp12s0f0
     default: enp11s0f0
-  port:
-    server: 9696
-    metadata: 8775
+  server:
+    name: "neutron-server"
+    port: 9696
+    node_port:
+      enabled: false
+      port: 30096
+  metadata:
+    name: "neutron-metadata"
+    port: 8775
 
 memcached:
   host: memcached

--- a/nova/templates/deployment-api-metadata.yaml
+++ b/nova/templates/deployment-api-metadata.yaml
@@ -63,10 +63,10 @@ spec:
             - nova-api-metadata
             - --config-file=/etc/nova/nova.conf
           ports:
-            - containerPort: {{ .Values.network.port.metadata }}
+            - containerPort: {{ .Values.network.metadata.port }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.network.port.metadata }}
+              port: {{ .Values.network.metadata.port }}
           volumeMounts:
             - name: novaconf
               mountPath: /etc/nova/nova.conf

--- a/nova/templates/deployment-api-osapi.yaml
+++ b/nova/templates/deployment-api-osapi.yaml
@@ -62,10 +62,10 @@ spec:
             - nova-api
             - --config-file=/etc/nova/nova.conf
           ports:
-            - containerPort: {{ .Values.network.port.osapi }}
+            - containerPort: {{ .Values.network.osapi.port }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.network.port.osapi }}
+              port: {{ .Values.network.osapi.port }}
           volumeMounts:
             - name: novaconf
               mountPath: /etc/nova/nova.conf

--- a/nova/templates/etc/_nova.conf.tpl
+++ b/nova/templates/etc/_nova.conf.tpl
@@ -23,7 +23,7 @@ force_config_drive = {{ .Values.nova.default.force_config_drive }}
 state_path = /var/lib/nova
 
 osapi_compute_listen = {{ .Values.network.ip_address }}
-osapi_compute_listen_port = {{ .Values.network.port.osapi }}
+osapi_compute_listen_port = {{ .Values.network.osapi.port }}
 osapi_compute_workers = {{ .Values.nova.default.osapi_workers }}
 
 workers = {{ .Values.nova.default.osapi_workers }}
@@ -44,11 +44,11 @@ transport_url = rabbit://{{ .Values.rabbitmq.admin_user }}:{{ .Values.rabbitmq.a
 
 [vnc]
 novncproxy_host = {{ .Values.network.ip_address }}
-novncproxy_port = {{ .Values.network.port.novncproxy }}
+novncproxy_port = {{ .Values.network.novncproxy.port }}
 vncserver_listen = 0.0.0.0
 vncserver_proxyclient_address = {{ .Values.network.ip_address }}
 
-novncproxy_base_url = http://{{ .Values.network.external_ips }}:{{ .Values.network.port.novncproxy }}/vnc_auto.html
+novncproxy_base_url = http://{{ .Values.network.external_ips }}:{{ .Values.network.novncproxy.port }}/vnc_auto.html
 
 [oslo_concurrency]
 lock_path = /var/lib/nova/tmp

--- a/nova/templates/service-metadata.yaml
+++ b/nova/templates/service-metadata.yaml
@@ -19,6 +19,12 @@ metadata:
 spec:
   ports:
   - name: nova-metadata
-    port: {{ .Values.network.port.metadata }}
+    port: {{ .Values.network.metadata.port }}
+    {{ if .Values.network.metadata.node_port.enabled }}
+      nodePort: {{ .Values.network.metadata.node_port.port }}
+    {{ end }}
   selector:
     app: nova-api
+  {{ if .Values.network.metadata.node_port.enabled }}
+  type: NodePort
+  {{ end }}

--- a/nova/templates/service-osapi.yaml
+++ b/nova/templates/service-osapi.yaml
@@ -22,6 +22,12 @@ metadata:
 spec:
   ports:
   - name: nova-osapi
-    port: {{ .Values.network.port.osapi }}
+    port: {{ .Values.network.osapi.port }}
+    {{ if .Values.network.osapi.node_port.enabled }}
+      nodePort: {{ .Values.network.osapi.node_port.port }}
+    {{ end }}
   selector:
     app: nova-osapi
+  {{ if .Values.network.osapi.node_port.enabled }}
+  type: NodePort
+  {{ end }}

--- a/nova/values.yaml
+++ b/nova/values.yaml
@@ -61,11 +61,21 @@ network:
       - "8.8.8.8"
     kubernetes_domain: "cluster.local"
     other_domains: ""
-
-  port:
-    osapi: 8774
-    metadata: 8775
-    novncproxy: 6080
+  osapi:
+    name: "nova-osapi"
+    port: 8774
+    node_port:
+      enabled: false
+      port: 30774
+  metadata:
+    name: "nova-metadata"
+    port: 8775
+    node_port:
+      enabled: false
+      port: 30775
+  novncproxy:
+    name: "nova-novncproxy"
+    port: 6080
 
 nova:
   default:


### PR DESCRIPTION
<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: 
Allows a NodePort for each service to be exposed.

**What issue does this pull request address?**: Fixes #297 

**Notes for reviewers to consider**:
After speaking with Brandon, he said we would want to mimic what the Heat files look like. This is why there are changes in the network section of the values file for each service on top of adding the NodePort boolean.

**Specific reviewers for pull request**:
@alanmeadows @v1k0d3n @larryrensing @intlabs @wilkers-steve 
