### PR TITLE
feat: WiP: Add support for Cinder multibackend (#321)

### DIFF
--- a/cinder/values.yaml
+++ b/cinder/values.yaml
@@ -84,12 +84,13 @@ ceph:
   cinder_keyring: null
 
 backends:
-  enabled:
-  - rbd1
+  # list all of your backend configs here
   rbd1:
-    secret: null
-    user: "admin"
-    pool: "volumes"
+    volume_driver: "cinder.volume.drivers.rbd.RBDDriver"
+    volume_backend_name: "rbd1"
+    rbd_secret_uuid: null
+    rbd_user: "admin"
+    rbd_pool: "volumes"
 
 glance:
   version: 2

--- a/helm-toolkit/templates/_funcs.tpl
+++ b/helm-toolkit/templates/_funcs.tpl
@@ -16,6 +16,10 @@
 {{ range $k, $v := . }}{{ if $k }},{{ end }}{{ $v }}{{ end }}
 {{- end -}}
 
+{{- define "helm-toolkit.joinMapKeysWithComma" -}}
+{{ range $k, $v := . }}{{ $k }},{{ end }}
+{{- end -}}
+
 {{- define "helm-toolkit.template" -}}
 {{- $name := index . 0 -}}
 {{- $context := index . 1 -}}


### PR DESCRIPTION
A single cinder-volume service is able to handle more than one volume
backend. This commit extends _cinder.conf.tpl to be able to handle
setting multiple backends. As each of Cinder volume drivers can define
its own configuration options, the cinder/values.yaml is made more
generic and will write any option set for a certain backend directly
into cinder.conf.

<!--  
      Thanks for contributing to OpenStack-Helm!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**:

**What issue does this pull request address?**: Fixes #

**Notes for reviewers to consider**:

**Specific reviewers for pull request**:
