### PR TITLE
fixes #324: Add missing "[]" to job-bootstrap.yaml

### DIFF
--- a/nova/templates/job-bootstrap.yaml
+++ b/nova/templates/job-bootstrap.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
-{{ tuple $envAll $dependencies | include "helm-toolkit.kubernetes_entrypoint_init_container" | indent 10 }}
+{{ tuple $envAll $dependencies "[]" | include "helm-toolkit.kubernetes_entrypoint_init_container" | indent 10 }}
         ]'
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
Commit afcf1c98485 was merged with obsolete syntax, causing nova
installation to fail as nova/templates/job-bootstrap.yaml was
incorrectly generated. This commit fixes this.

**What is the purpose of this pull request?**: Fix #324 

**What issue does this pull request address?**: Fixes #324 

**Notes for reviewers to consider**:

**Specific reviewers for pull request**:
