### PR TITLE
Add default dns server in dhcp agent conf.

### DIFF
--- a/neutron/templates/etc/_dhcp-agent.ini.tpl
+++ b/neutron/templates/etc/_dhcp-agent.ini.tpl
@@ -17,3 +17,4 @@ dnsmasq_config_file = /etc/neutron/dnsmasq.conf
 enable_isolated_metadata = true
 force_metadata = true
 interface_driver = openvswitch
+server=8.8.8.8


### PR DESCRIPTION
When running simple VXLAN network, VMs does not have access to DNS.
The dhcp agent pod configuration is pointing to k8s dns, but dnsmasq
agent does not have access to it within its namespace. Due to security
reasons, it should not have access to k8s underlay infra, so adding
generic 8.8.8.8 DNS server address.

**What is the purpose of this pull request?**:
Add default DNS server for simple DHCP agent configuration. 

**What issue does this pull request address?**: 
When installing OpenStack-Helm out of the box, creating the simple VXLAN network without specifying DNS server while creating subnet, VMs launched would not have access to the DNS server.

**Notes for reviewers to consider**:
Adding hardcoded 8.8.8.8 to the DHCP agent config. It maybe good to add it as config option.

**Specific reviewers for pull request**:
