### PR TITLE
Add VXLAN as L3HA network type.

### DIFF
--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -129,7 +129,7 @@ metadata_agent:
 neutron:
   workers: 4
   default:
-    l3_ha_network_type: gre
+    l3_ha_network_type: vxlan
     debug: 'True'
 metadata:
   workers: 4
@@ -161,6 +161,7 @@ ml2:
     auto_bridge_add:
       br-physnet1: enp11s0f0
     bridge_mappings:
+      - "external:br-ex"
       - "physnet1:br-physnet1"
 
 dependencies:


### PR DESCRIPTION
Default value 'gre' is not supported mechanism driver for current config.
Also added 'external' bridge mapping for creating external provider networks.

**What is the purpose of this pull request?**:
Correct the default config to create VXLAN HA networks for VRRP.

**What issue does this pull request address?**: Fixes #
In default configuration, the creation of neutron router will fail, because the 'gre' network type is not supported in mechnism drivers configuration.

**Notes for reviewers to consider**:

**Specific reviewers for pull request**:
